### PR TITLE
Added utcnow.get_today() / utcnow.as_date_string()

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,36 @@ result = f"Current server time is: '{utcnow}'"
 # "Current server time is: '2021-02-18T08:24:48.382262Z'"
 ```
 
+### Get the date part as a string from a timestamp
+
+Not as common, but every now and then you might need to get the date part from a timestamp (or for example today's date), to use in some string concatenation, S3 object keys and what not.
+
+There's the long away around it, by generating a timestamp with `utcnow.get()` and then just keeping the first 10 characters of the timestamp – that's the date – `YYYY-MM-DD`. You could even use `datetime` and go `datetime.datetime.utcnow().date().isoformat()`, but it's not super clean.
+
+`utcnow` comes with a wrapper function `utcnow.as_date_string(value)` to fetch just the date part based on the input value's UTC timestamp. Note that the date string that is returned does not include timezone information.
+
+```python
+import utcnow
+
+timestamp = "2022-04-05T13:44:52.748994Z"
+utcnow.as_date_string(timestamp)
+# "2022-04-05"
+```
+
+Bonus 🎉🎉 – calling the `utcnow.as_date_string()` function without arguments will return today's date, _based on the current time in UTC_. For some sugar to your code, the same function is also available under the name `utcnow.get_today()`.
+
+To get the current date in another timezone use the keyword argument `tz` to the function call. The value for `tz` should be either a `datetime.tzinfo` object or an utcoffset represented as a string (for example "+01:00", "-06:00", etc.).
+
+```python
+import utcnow
+
+utcnow.get_today()
+# "2022-04-05" (it's the 5th of April when typing this)
+
+utcnow.get_today(tz="+12:00")
+# "2022-04-06" (time in UTC is currently 15:12 - adding 12 hours to that would yield 03:12 tomorrow)
+```
+
 ### How much time between timestamp A and timestamp B?
 
 The library also comes with a small utility function for calculating the number of seconds (usually) between two timestamps.It's called `utcnow.timediff` and works like this.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,12 +1,4 @@
 [[package]]
-name = "atomicwrites"
-version = "1.4.0"
-description = "Atomic file writes."
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
 name = "attrs"
 version = "21.4.0"
 description = "Classes Without Boilerplate"
@@ -64,11 +56,11 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "8.0.4"
+version = "8.1.2"
 description = "Composable command line interface toolkit"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
@@ -322,9 +314,7 @@ optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
@@ -407,28 +397,28 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "urllib3"
-version = "1.26.8"
+version = "1.26.9"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
-brotli = ["brotlipy (>=0.6.0)"]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "zipp"
-version = "3.7.0"
+version = "3.8.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
@@ -436,10 +426,6 @@ python-versions = "^3.7"
 content-hash = "206f8d406c31b56797edb8fa41961719836de99912bf9efc0db2e8274d7fd7bf"
 
 [metadata.files]
-atomicwrites = [
-    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
-    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
-]
 attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
@@ -478,8 +464,8 @@ charset-normalizer = [
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 click = [
-    {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
-    {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
+    {file = "click-8.1.2-py3-none-any.whl", hash = "sha256:24e1a4a9ec5bf6299411369b208c1df2188d9eb8d916302fe6bf03faed227f1e"},
+    {file = "click-8.1.2.tar.gz", hash = "sha256:479707fe14d9ec9a0757618b7a100a0ae4c4e236fac5b7f80ca68028141a1a72"},
 ]
 codecov = [
     {file = "codecov-2.1.12-py2.py3-none-any.whl", hash = "sha256:585dc217dc3d8185198ceb402f85d5cb5dbfa0c5f350a5abcdf9e347776a5b47"},
@@ -677,10 +663,10 @@ typing-extensions = [
     {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},
-    {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
+    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
+    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
 ]
 zipp = [
-    {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},
-    {file = "zipp-3.7.0.tar.gz", hash = "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"},
+    {file = "zipp-3.8.0-py3-none-any.whl", hash = "sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099"},
+    {file = "zipp-3.8.0.tar.gz", hash = "sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad"},
 ]

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -130,7 +130,7 @@ def test_dates(value: str, expect_error: bool) -> None:
         assert True
 
 
-def test_as_date_string():
+def test_as_date_string() -> None:
     date_today_0 = datetime.datetime.utcnow().date().isoformat()
     assert utcnow.get_today() == date_today_0 or utcnow.get_today() == datetime.datetime.utcnow().date().isoformat()
 
@@ -160,7 +160,7 @@ def test_as_date_string():
         utcnow.get_today(tz="UnknownTimezone")
 
     with pytest.raises(ValueError):
-        utcnow.get_today(tz=datetime.timezone)
+        utcnow.get_today(tz=datetime.timezone)  # type:ignore
 
     with pytest.raises(ValueError):
         utcnow.get_today(tz="+32:00")

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,7 +1,8 @@
 import datetime
-import utcnow
 
 import pytest
+
+import utcnow
 
 
 @pytest.mark.parametrize(
@@ -139,11 +140,21 @@ def test_as_date_string():
     assert utcnow.get_today(tz="+24:00") != utcnow.get_today()
     assert utcnow.get_today(tz="-24:00") != utcnow.get_today()
 
-    assert utcnow.get_today(tz="UTC") == date_today_0 or utcnow.get_today(tz="UTC") == datetime.datetime.utcnow().date().isoformat()
-    assert utcnow.get_today(tz=datetime.timezone.utc) == date_today_0 or utcnow.get_today(tz=datetime.timezone.utc) == datetime.datetime.utcnow().date().isoformat()
+    assert (
+        utcnow.get_today(tz="UTC") == date_today_0
+        or utcnow.get_today(tz="UTC") == datetime.datetime.utcnow().date().isoformat()
+    )
+    assert (
+        utcnow.get_today(tz=datetime.timezone.utc) == date_today_0
+        or utcnow.get_today(tz=datetime.timezone.utc) == datetime.datetime.utcnow().date().isoformat()
+    )
 
     assert utcnow.get_today(tz=datetime.timezone(datetime.timedelta(hours=24, microseconds=-1))) != utcnow.get_today()
-    assert utcnow.get_today(tz=datetime.timezone(datetime.timedelta(hours=24, microseconds=-1))) == utcnow.get_today(tz="+24:00") or utcnow.get_today(tz=datetime.timezone(datetime.timedelta(hours=24, microseconds=-1))) == utcnow.get_today(tz="+24:00")
+    assert utcnow.get_today(tz=datetime.timezone(datetime.timedelta(hours=24, microseconds=-1))) == utcnow.get_today(
+        tz="+24:00"
+    ) or utcnow.get_today(tz=datetime.timezone(datetime.timedelta(hours=24, microseconds=-1))) == utcnow.get_today(
+        tz="+24:00"
+    )
 
     with pytest.raises(ValueError):
         utcnow.get_today(tz="UnknownTimezone")

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -135,3 +135,24 @@ def test_as_date_string():
 
     assert utcnow.as_date_string("2022-04-04") == "2022-04-04"
     assert utcnow.as_date_string("2021-01-02T00:00:00.04000Z") == "2021-01-02"
+
+    assert utcnow.get_today(tz="+24:00") != utcnow.get_today()
+    assert utcnow.get_today(tz="-24:00") != utcnow.get_today()
+
+    assert utcnow.get_today(tz="UTC") == date_today_0 or utcnow.get_today(tz="UTC") == datetime.datetime.utcnow().date().isoformat()
+    assert utcnow.get_today(tz=datetime.timezone.utc) == date_today_0 or utcnow.get_today(tz=datetime.timezone.utc) == datetime.datetime.utcnow().date().isoformat()
+
+    assert utcnow.get_today(tz=datetime.timezone(datetime.timedelta(hours=24, microseconds=-1))) != utcnow.get_today()
+    assert utcnow.get_today(tz=datetime.timezone(datetime.timedelta(hours=24, microseconds=-1))) == utcnow.get_today(tz="+24:00") or utcnow.get_today(tz=datetime.timezone(datetime.timedelta(hours=24, microseconds=-1))) == utcnow.get_today(tz="+24:00")
+
+    with pytest.raises(ValueError):
+        utcnow.get_today(tz="UnknownTimezone")
+
+    with pytest.raises(ValueError):
+        utcnow.get_today(tz=datetime.timezone)
+
+    with pytest.raises(ValueError):
+        utcnow.get_today(tz="+32:00")
+
+    with pytest.raises(ValueError):
+        utcnow.get_today(tz="-32:00")

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -167,3 +167,6 @@ def test_as_date_string() -> None:
 
     with pytest.raises(ValueError):
         utcnow.get_today(tz="-32:00")
+
+    with pytest.raises(ValueError):
+        utcnow.get_today(tz="+TEST")

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,4 +1,5 @@
 import datetime
+import utcnow
 
 import pytest
 
@@ -126,3 +127,11 @@ def test_dates(value: str, expect_error: bool) -> None:
             assert False
 
         assert True
+
+
+def test_as_date_string():
+    date_today_0 = datetime.datetime.utcnow().date().isoformat()
+    assert utcnow.get_today() == date_today_0 or utcnow.get_today() == datetime.datetime.utcnow().date().isoformat()
+
+    assert utcnow.as_date_string("2022-04-04") == "2022-04-04"
+    assert utcnow.as_date_string("2021-01-02T00:00:00.04000Z") == "2021-01-02"

--- a/tests/test_module_calls.py
+++ b/tests/test_module_calls.py
@@ -140,7 +140,7 @@ def test_module() -> None:
     )
 
     # Testing function imports
-    from utcnow import as_str, as_string
+    from utcnow import as_str, as_string, as_date_string
     from utcnow import str as str_
     from utcnow import string
 
@@ -148,6 +148,7 @@ def test_module() -> None:
     assert as_str("1984-08-01") == "1984-08-01T00:00:00.000000Z"
     assert string("1984-08-01") == "1984-08-01T00:00:00.000000Z"
     assert str_("1984-08-01") == "1984-08-01T00:00:00.000000Z"
+    assert as_date_string("1984-08-01") == "1984-08-01"
     assert datetime.datetime.strptime(as_string(), "%Y-%m-%dT%H:%M:%S.%f%z")
     assert datetime.datetime.strptime(as_str(), "%Y-%m-%dT%H:%M:%S.%f%z")
     assert datetime.datetime.strptime(string(), "%Y-%m-%dT%H:%M:%S.%f%z")
@@ -161,6 +162,8 @@ def test_module() -> None:
     assert utcnow_.as_str("1984-08-01") == "1984-08-01T00:00:00.000000Z"
     assert utcnow_.string("1984-08-01") == "1984-08-01T00:00:00.000000Z"
     assert utcnow_.str("1984-08-01") == "1984-08-01T00:00:00.000000Z"
+    assert utcnow_.as_date_string("1984-08-01") == "1984-08-01"
+    assert utcnow_.get_today()
     assert datetime.datetime.strptime(utcnow_(), "%Y-%m-%dT%H:%M:%S.%f%z")
     assert datetime.datetime.strptime(utcnow_.as_string(), "%Y-%m-%dT%H:%M:%S.%f%z")
     assert datetime.datetime.strptime(utcnow_.as_str(), "%Y-%m-%dT%H:%M:%S.%f%z")

--- a/tests/test_module_calls.py
+++ b/tests/test_module_calls.py
@@ -140,7 +140,7 @@ def test_module() -> None:
     )
 
     # Testing function imports
-    from utcnow import as_str, as_string, as_date_string
+    from utcnow import as_date_string, as_str, as_string
     from utcnow import str as str_
     from utcnow import string
 

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -234,6 +234,11 @@ class utcnow_(_baseclass):
             date_tz = UTC
         elif isinstance(tz, str_) and re.match(r"^[+-][0-9]{2}:?[0-9]{2}$", tz):
             m = re.match(r"^[+-]([0-9]{2}):?([0-9]{2})$", tz)
+            if not m:
+                raise ValueError(
+                    f"Unknown timezone value '{tz}' (string) - use value of type 'datetime.tzinfo' or an utcoffset string value"
+                )
+
             modifier = 1 if tz.startswith("+") else -1
 
             td = timedelta_(hours=int(m.group(1)), minutes=int(m.group(2)))

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -203,6 +203,13 @@ class utcnow_(_baseclass):
 
         raise ValueError(f"Unknown unit '{unit}' for utcnow.timediff")
 
+    def as_date_string(self, value: Union[str_, datetime_, object, int, float, Decimal, Real] = _SENTINEL) -> str_:
+        if value is _SENTINEL:
+            str_value = datetime_.utcnow().isoformat(timespec="microseconds") + "Z"
+        else:
+            str_value = _transform_value(value)
+        return str_value[0:10]
+
     as_str = as_string
     as_rfc3339 = as_string
     to_string = as_string
@@ -268,6 +275,28 @@ class utcnow_(_baseclass):
     diff = timediff
     timedelta = timediff
     delta = timediff
+
+    as_datestring = as_date_string
+    as_date_str = as_date_string
+    as_datestr = as_date_string
+    to_date_string = as_date_string
+    to_datestring = as_date_string
+    to_date_str = as_date_string
+    to_datestr = as_date_string
+    get_date_string = as_date_string
+    get_datestring = as_date_string
+    get_datestr = as_date_string
+    get_date_string = as_date_string
+    get_today = as_date_string
+    get_today_date = as_date_string
+    get_date_today = as_date_string
+    date_today = as_date_string
+    today_date = as_date_string
+    today = as_date_string
+    date_string = as_date_string
+    datestring = as_date_string
+    date_str = as_date_string
+    datestr = as_date_string
 
     def __str__(self) -> str_:
         return self.as_string()
@@ -366,6 +395,29 @@ diff = timediff
 timedelta = timediff
 delta = timediff
 
+as_date_string = _module_value.as_date_string
+as_datestring = as_date_string
+as_date_str = as_date_string
+as_datestr = as_date_string
+to_date_string = as_date_string
+to_datestring = as_date_string
+to_date_str = as_date_string
+to_datestr = as_date_string
+get_date_string = as_date_string
+get_datestring = as_date_string
+get_date_str = as_date_string
+get_datestr = as_date_string
+get_today = as_date_string
+get_today_date = as_date_string
+get_date_today = as_date_string
+date_today = as_date_string
+today_date = as_date_string
+today = as_date_string
+date_string = as_date_string
+datestring = as_date_string
+date_str = as_date_string
+datestr = as_date_string
+
 
 __all__ = [
     "__version__",
@@ -440,6 +492,28 @@ __all__ = [
     "diff",
     "timedelta",
     "delta",
+    "as_date_string",
+    "as_datestring",
+    "as_date_str",
+    "as_datestr",
+    "to_date_string",
+    "to_datestring",
+    "to_date_str",
+    "to_datestr",
+    "get_date_string",
+    "get_datestring",
+    "get_date_str",
+    "get_datestr",
+    "get_today",
+    "get_today_date",
+    "get_date_today",
+    "date_today",
+    "today_date",
+    "today",
+    "date_string",
+    "datestring",
+    "date_str",
+    "datestr",
 ]
 
 _actual_module = sys.modules[__name__]  # noqa

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -5,8 +5,8 @@ import re
 import sys
 import time as time_
 from datetime import datetime as datetime_
-from datetime import timezone as timezone_
 from datetime import timedelta as timedelta_
+from datetime import timezone as timezone_
 from datetime import tzinfo as tzinfo_
 from decimal import Decimal
 from numbers import Real
@@ -205,13 +205,32 @@ class utcnow_(_baseclass):
 
         raise ValueError(f"Unknown unit '{unit}' for utcnow.timediff")
 
-    def as_date_string(self, value: Union[str_, datetime_, object, int, float, Decimal, Real] = _SENTINEL, tz: Optional[Union[str_, tzinfo_]] = None) -> str_:
+    def as_date_string(
+        self,
+        value: Union[str_, datetime_, object, int, float, Decimal, Real] = _SENTINEL,
+        tz: Optional[Union[str_, tzinfo_]] = None,
+    ) -> str_:
         date_tz: tzinfo_
         if not tz:
             date_tz = UTC
         elif isinstance(tz, tzinfo_):
             date_tz = tz
-        elif isinstance(tz, str_) and tz.upper() in ("UTC", "GMT", "UTC+0", "UTC-0", "GMT+0", "GMT-0", "Z", "ZULU", "00:00", "+00:00", "-00:00", "0000", "+0000", "-0000"):
+        elif isinstance(tz, str_) and tz.upper() in (
+            "UTC",
+            "GMT",
+            "UTC+0",
+            "UTC-0",
+            "GMT+0",
+            "GMT-0",
+            "Z",
+            "ZULU",
+            "00:00",
+            "+00:00",
+            "-00:00",
+            "0000",
+            "+0000",
+            "-0000",
+        ):
             date_tz = UTC
         elif isinstance(tz, str_) and re.match(r"^[+-][0-9]{2}:?[0-9]{2}$", tz):
             m = re.match(r"^[+-]([0-9]{2}):?([0-9]{2})$", tz)
@@ -223,9 +242,13 @@ class utcnow_(_baseclass):
 
             date_tz = timezone_(modifier * td)
         elif isinstance(tz, str_):
-            raise ValueError(f"Unknown timezone value '{tz}' (string) - use value of type 'datetime.tzinfo' or an utcoffset string value")
+            raise ValueError(
+                f"Unknown timezone value '{tz}' (string) - use value of type 'datetime.tzinfo' or an utcoffset string value"
+            )
         else:
-            raise ValueError(f"Unknown timezone value '{tz}' (type: {tz.__class__}) - should preferably be of type 'datetime.tzinfo'")
+            raise ValueError(
+                f"Unknown timezone value '{tz}' (type: {tz.__class__}) - should preferably be of type 'datetime.tzinfo'"
+            )
 
         if value is _SENTINEL:
             return datetime_.now(date_tz).date().isoformat()

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -234,7 +234,7 @@ class utcnow_(_baseclass):
             date_tz = UTC
         elif isinstance(tz, str_) and re.match(r"^[+-][0-9]{2}:?[0-9]{2}$", tz):
             m = re.match(r"^[+-]([0-9]{2}):?([0-9]{2})$", tz)
-            if not m:
+            if not m:  # pragma: no cover
                 raise ValueError(
                     f"Unknown timezone value '{tz}' (string) - use value of type 'datetime.tzinfo' or an utcoffset string value"
                 )


### PR DESCRIPTION
Not as common, but every now and then you might need to get the date part from a timestamp (or for example today's date), to use in some string concatenation, S3 object keys and what not.

There's the long away around it, by generating a timestamp with `utcnow.get()` and then just keeping the first 10 characters of the timestamp – that's the date – `YYYY-MM-DD`. You could even use `datetime` and go `datetime.datetime.utcnow().date().isoformat()`, but it's not super clean.

`utcnow` comes with a wrapper function `utcnow.as_date_string(value)` to fetch just the date part based on the input value's UTC timestamp. Note that the date string that is returned does not include timezone information.

```python
import utcnow

timestamp = "2022-04-05T13:44:52.748994Z"
utcnow.as_date_string(timestamp)
# "2022-04-05"
```

Bonus 🎉🎉 – calling the `utcnow.as_date_string()` function without arguments will return today's date, _based on the current time in UTC_. For some sugar to your code, the same function is also available under the name `utcnow.get_today()`.

To get the current date in another timezone use the keyword argument `tz` to the function call. The value for `tz` should be either a `datetime.tzinfo` object or an utcoffset represented as a string (for example "+01:00", "-06:00", etc.).

```python
import utcnow

utcnow.get_today()
# "2022-04-05" (it's the 5th of April when typing this)

utcnow.get_today(tz="+12:00")
# "2022-04-06" (time in UTC is currently 15:12 - adding 12 hours to that would yield 03:12 tomorrow)
```