### PR TITLE
Support to transform from (and if necessary, to) Protocol Buffers messages of type google.protobuf.Timestamp 

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,7 +32,7 @@ jobs:
         echo "$HOME/.poetry/bin" >> $GITHUB_PATH
     - name: Install dependencies
       run: |
-        poetry install --no-interaction
+        poetry install -E protobuf --no-interaction
         poetry show --tree
     - name: Test poetry build step
       run: poetry build

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ default:
 	@echo "- make release      | upload dist and push tag"
 
 install:
-	poetry install
+	poetry install -E protobuf
 
 pytest:
 	PYTHONPATH=. poetry run pytest --cov-report term-missing --cov=${PACKAGENAME}/ tests -v

--- a/README.md
+++ b/README.md
@@ -8,12 +8,31 @@
 
 *Timestamps as RFC 3339 (Date & Time on the Internet) formatted strings with conversion functionality from other timestamp formats or for timestamps on other timezones. Additionally converts timestamps from datetime objets and other common date utilities. Follow modern practices when developing API interfaces.*
 
+### A library for formatting timestamps as RFC3339
+
+* One preferred output format strictly following RFC3339.
+* Making it easier to follow common best practices for developers.
+* Tranforming timestamps from (or when needed, to) common interfaces such as unix timestamps, `datetime` objects, `google.protobuf.Timestamp` messages or plain text.
+* Type hinted, battle tested and supporting several versions of Python.
+
+```pycon
+>>> utcnow.rfc3339_timestamp()  # current time
+'2022-12-06T12:25:49.738032Z'
+
+>>> utcnow.rfc3339_timestamp("1984-08-01 22:31")
+'1984-08-01T22:31:00.000000Z'
+```
+
+#### Additional examples of simple use-cases
+
 ```python
 from utcnow import utcnow
 
-utcnow.get()
+utcnow.get()  # utcnow.get does the same thing as utcnow.rfc3339_timestamp
 # "2077-03-01T09:33:07.139361Z" | The most common use case – get current server time.
 #                               | Always uses UTC timezone in the returned value.
+#                               | utcnow.get() is the same as utcnow.rfc3339_timestamp().
+
 ```
 
 ```python
@@ -213,6 +232,11 @@ Like you would install any other Python package, use `pip`, `poetry`, `pipenv` o
 $ pip install utcnow
 ```
 
+To install with Protocol Buffers support, specify the `protobuf` extras.
+
+```
+$ pip install utcnow[protobuf]
+```
 
 ## Usage and examples
 
@@ -367,6 +391,43 @@ result = json.dumps({"timestamp": str(utcnow), "status": 200})
 import utcnow
 result = f"Current server time is: '{utcnow}'"
 # "Current server time is: '2021-02-18T08:24:48.382262Z'"
+```
+
+### Converting from Protocol Buffers message
+
+It's also possible to transform a value encoded as a `google.protobuf.Timestamp` protobuf message in the same way you would from any other value.
+
+```python
+# Using a google.protobuf.Timestamp message as input to utcnow
+import utcnow
+from google.protobuf.timestamp_pb2 import Timestamp
+msg = Timestamp(seconds=1670329924, nanos=170660000)
+result = utcnow.get(msg)
+# "2022-12-06T12:32:04.170660Z"
+```
+
+```python
+# Using the binary data from a google.protobuf.Timestamp message
+import utcnow
+protobuf_msg_binary = b"\x08\xc4\xec\xbc\x9c\x06\x10\xa0\xa1\xb0Q"
+result = utcnow.get(protobuf_msg_binary)
+# "2022-12-06T12:32:04.170660Z"
+```
+
+You can also generate a new google.protobuf.Timestamp message using `utcnow.as_protobuf()`
+
+```python
+import utcnow
+msg = utcnow.as_protobuf("1984-08-01 22:30:47.234003Z")
+# <class 'google.protobuf.timestamp_pb2.Timestamp'>
+# · seconds: 460247447
+# · nanos: 234003000
+```
+
+Note that the `protobuf` package has to be installed to make use of the above functionality. For convenience, it's also possible to install `utcnow` with `protobuf` support using the `protobuf` extras.
+
+```
+$ pip install utcnow[protobuf]
 ```
 
 ### Get the date part as a string from a timestamp

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ result = utcnow.get(protobuf_msg_binary)
 # "2022-12-06T12:32:04.170660Z"
 ```
 
-You can also generate a new google.protobuf.Timestamp message using `utcnow.as_protobuf()`
+You can also generate a new `google.protobuf.Timestamp` message using `utcnow.as_protobuf()`
 
 ```python
 import utcnow

--- a/poetry.lock
+++ b/poetry.lock
@@ -285,6 +285,14 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "protobuf"
+version = "4.21.10"
+description = ""
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "pycodestyle"
 version = "2.9.1"
 description = "Python style guide checker"
@@ -381,6 +389,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "types-protobuf"
+version = "4.21.0.2"
+description = "Typing stubs for protobuf"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -426,11 +442,12 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [extras]
 cli = ["utcnow-cli"]
+protobuf = ["protobuf"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "40b55ab28896364fe8e3579499370b3d6cab6bd06a2710cd2d7548f10092e66b"
+content-hash = "b650af2a4690b1679b361f20eac75366ce3e5bd6c0b6191fa85b8dc83f03fa01"
 
 [metadata.files]
 attrs = [
@@ -621,6 +638,22 @@ pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
+protobuf = [
+    {file = "protobuf-4.21.10-cp310-abi3-win32.whl", hash = "sha256:e92768d17473657c87e98b79a4c7724b0ddfa23211b05ce137bfdc55e734e36f"},
+    {file = "protobuf-4.21.10-cp310-abi3-win_amd64.whl", hash = "sha256:0c968753028cb14b1d24cc839723f7e9505b305fc588a37a9e0f7d270cb59d89"},
+    {file = "protobuf-4.21.10-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:e53165dd14d19abc7f50733f365de431e51d1d262db40c0ee22e271a074fac59"},
+    {file = "protobuf-4.21.10-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:5efa8a8162ada7e10847140308fbf84fdc5b89dc21655d12ec04aed87284fe07"},
+    {file = "protobuf-4.21.10-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:2a172741b5b041a896b621cef4277077afd571e0d3a6e524e7171f1c70e33200"},
+    {file = "protobuf-4.21.10-cp37-cp37m-win32.whl", hash = "sha256:05cbcb9a25cd781fd949f93f6f98a911883868c0360c6d2264fc99a903c8f0d7"},
+    {file = "protobuf-4.21.10-cp37-cp37m-win_amd64.whl", hash = "sha256:3f08f04b4f101dd469efbcc1731fbf48068eccd8a42f4e2ea530aa012a5f56f8"},
+    {file = "protobuf-4.21.10-cp38-cp38-win32.whl", hash = "sha256:6b809f20923b6ef49dc1755cb50bdb21be179b4a3c7ffcab1fe5d3f139b58a51"},
+    {file = "protobuf-4.21.10-cp38-cp38-win_amd64.whl", hash = "sha256:81b233a06c62387ea5c9be2cd9aedd2ba09940e91da53b920e9ff5bd98e48e7f"},
+    {file = "protobuf-4.21.10-cp39-cp39-win32.whl", hash = "sha256:b78d7c2c36b51c0041b9bf000be4adb09f4112bfc40bc7a9d48ac0b0dfad139e"},
+    {file = "protobuf-4.21.10-cp39-cp39-win_amd64.whl", hash = "sha256:0413addc126c40a5440ee59be098de1007183d68e9f5f20ed5fbc44848f417ca"},
+    {file = "protobuf-4.21.10-py2.py3-none-any.whl", hash = "sha256:a5e89eabaa0ca72ce1b7c8104a740d44cdb67942cbbed00c69a4c0541de17107"},
+    {file = "protobuf-4.21.10-py3-none-any.whl", hash = "sha256:5096b3922b45e4b7a04d3d3cb855d13bb5ccd4d5e44b129e706232ebf0ffb870"},
+    {file = "protobuf-4.21.10.tar.gz", hash = "sha256:4d97c16c0d11155b3714a29245461f0eb60cace294455077f3a3b8a629afa383"},
+]
 pycodestyle = [
     {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
     {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
@@ -674,6 +707,10 @@ typed-ast = [
     {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
     {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
     {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
+]
+types-protobuf = [
+    {file = "types-protobuf-4.21.0.2.tar.gz", hash = "sha256:7df483d34ad3fcb1fa7fff1073560d596c9ac1f419cfa851b220c9a93386c998"},
+    {file = "types_protobuf-4.21.0.2-py3-none-any.whl", hash = "sha256:aeefcf39d637016998b3c7b699750847071b555f7c2e0c9873d42ab6103d1a39"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -157,6 +157,17 @@ isort = ">=4.3.5,<6"
 test = ["pytest"]
 
 [[package]]
+name = "freezegun"
+version = "1.2.2"
+description = "Let your Python tests travel through time"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "idna"
 version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -355,6 +366,17 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "requests"
 version = "2.28.1"
 description = "Python HTTP for Humans."
@@ -371,6 +393,14 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
@@ -447,7 +477,7 @@ protobuf = ["protobuf"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "b650af2a4690b1679b361f20eac75366ce3e5bd6c0b6191fa85b8dc83f03fa01"
+content-hash = "e50a77d32b93a92148136eef6d18bd50741dae5c43176d8dd28a4d1b48f6776a"
 
 [metadata.files]
 attrs = [
@@ -566,6 +596,10 @@ flake8-isort = [
     {file = "flake8-isort-5.0.3.tar.gz", hash = "sha256:0951398c343c67f4933407adbbfb495d4df7c038650c5d05753a006efcfeb390"},
     {file = "flake8_isort-5.0.3-py3-none-any.whl", hash = "sha256:8c4ab431d87780d0c8336e9614e50ef11201bc848ef64ca017532dec39d4bf49"},
 ]
+freezegun = [
+    {file = "freezegun-1.2.2-py3-none-any.whl", hash = "sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f"},
+    {file = "freezegun-1.2.2.tar.gz", hash = "sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446"},
+]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
     {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
@@ -674,9 +708,17 @@ pytest-cov = [
     {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
     {file = "pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
 ]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
 requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
     {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ black = { version = "*", markers = "sys_platform != \"win32\"", allow-prerelease
 mypy = { version = ">=0.800", markers = "sys_platform != \"win32\"" }
 codecov = { version = ">=2.1.10", markers = "sys_platform != \"win32\"" }
 protobuf = { version = ">=3.20.0,<5.0.0", markers = "sys_platform != \"win32\"" }
+freezegun ={ version = ">=1.2.2", markers = "sys_platform != \"win32\"" }
 types-protobuf = { version = ">=0.1.13", markers = "sys_platform != \"win32\"" }
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Timestamps as opinionated RFC 3339 (Date and Time on the Internet
 authors = ["Carl Oscar Aaro <hello@carloscar.com>"]
 homepage = "https://github.com/kalaspuff/utcnow"
 repository = "https://github.com/kalaspuff/utcnow"
-keywords = ["utcnow", "utc timestamp", "modern timestamp", "rfc 3339", "rfc3339", "timestamp", "timestamps", "date and time on the internet", "datetime", "zulu time"]
+keywords = ["utcnow", "utc timestamp", "modern timestamp", "rfc 3339", "rfc3339", "timestamp", "rfc3339 timestamp", "timestamps", "date and time on the internet", "datetime", "zulu time", "protobuf", "protobuf timestamp"]
 readme = "README.md"
 license = "MIT"
 classifiers = [
@@ -42,10 +42,12 @@ exclude = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
+protobuf = { version = ">=3.20.0,<5.0.0", optional = true }
 utcnow-cli = { version = ">=1.0.0", optional = true }
 
 [tool.poetry.extras]
 cli = ["utcnow-cli"]
+protobuf = ["protobuf"]
 
 [tool.poetry.dev-dependencies]
 flake8 = { version = ">=3.8.4", markers = "sys_platform != \"win32\"" }
@@ -57,6 +59,8 @@ pytest-cov = { version = ">=2.10.0", markers = "sys_platform != \"win32\"" }
 black = { version = "*", markers = "sys_platform != \"win32\"", allow-prereleases = true }
 mypy = { version = ">=0.800", markers = "sys_platform != \"win32\"" }
 codecov = { version = ">=2.1.10", markers = "sys_platform != \"win32\"" }
+protobuf = { version = ">=3.20.0,<5.0.0", markers = "sys_platform != \"win32\"" }
+types-protobuf = { version = ">=0.1.13", markers = "sys_platform != \"win32\"" }
 
 [build-system]
 requires = ["poetry_core>=1.0.0"]

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,6 +1,7 @@
 import datetime
 
 import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
 
 import utcnow
 
@@ -39,6 +40,7 @@ def test_dates(value: str, expect_error: bool) -> None:
         assert isinstance(utcnow.as_string(value), str)
         assert isinstance(utcnow.as_datetime(value), datetime.datetime)
         assert isinstance(utcnow.as_unixtime(value), (float, int))
+        assert isinstance(utcnow.as_protobuf(value), Timestamp)
         if expect_error:
             assert False
     except Exception:

--- a/tests/test_modifier.py
+++ b/tests/test_modifier.py
@@ -1,3 +1,5 @@
+from freezegun import freeze_time
+
 import utcnow
 
 
@@ -7,7 +9,7 @@ def test_rfc3339_modifier() -> None:
     assert utcnow.rfc3339_timestamp(1666019834.321119, "-10s") == "2022-10-17T15:17:04.321119Z"
 
 
-def test_unxitime_modifier() -> None:
+def test_unixtime_modifier() -> None:
     assert utcnow.unixtime(0, "+10s") == 10.0
     assert utcnow.unixtime(0, "+24h") == 86400.0
     assert utcnow.unixtime("now", None) < utcnow.unixtime("+1s")
@@ -18,7 +20,47 @@ def test_unxitime_modifier() -> None:
     )
 
 
-def test_unixtime_modifier() -> None:
+def test_datetime_modifier() -> None:
     assert utcnow.as_datetime("now", "+60s") > utcnow.as_datetime("now")
     assert utcnow.as_datetime("+60s") > utcnow.as_datetime("now")
     assert utcnow.as_datetime("-60s") < utcnow.as_datetime("now")
+
+
+def test_protobuf_modifier() -> None:
+    assert utcnow.unixtime(utcnow.as_protobuf(0, "+10s")) == 10.0
+    assert utcnow.unixtime(utcnow.as_protobuf(0, "+24h")) == 86400.0
+    assert utcnow.as_datetime(utcnow.as_protobuf("now", None)) < utcnow.as_datetime(utcnow.as_protobuf("+1s"))
+    assert (
+        utcnow.as_protobuf("2022-10-17T15:15:22.556084Z", None)
+        == utcnow.as_protobuf("2022-10-17T15:15:22.556084Z", 0)
+        == utcnow.as_protobuf("2022-10-17T15:15:22.556084Z")
+    )
+    assert utcnow.unixtime(utcnow.as_protobuf("+10s")) > utcnow.unixtime()
+    assert utcnow.unixtime(utcnow.as_protobuf("-10s")) < utcnow.unixtime()
+
+
+def test_sentinel_modifier() -> None:
+    with freeze_time("1970-01-01"):
+        assert utcnow.rfc3339_timestamp() == utcnow.rfc3339_timestamp()
+        assert utcnow.unixtime() == utcnow.unixtime()
+        assert utcnow.as_datetime() == utcnow.as_datetime()
+        assert utcnow.as_protobuf() == utcnow.as_protobuf()
+        assert utcnow.rfc3339_timestamp(0) == utcnow.rfc3339_timestamp()
+        assert utcnow.unixtime(0) == utcnow.unixtime()
+        assert utcnow.as_datetime(0) == utcnow.as_datetime()
+        assert utcnow.as_protobuf(0) == utcnow.as_protobuf()
+        assert utcnow.rfc3339_timestamp("+1s") > utcnow.rfc3339_timestamp()
+        assert utcnow.unixtime("+1s") == utcnow.unixtime() + 1
+        assert utcnow.as_datetime("+1s") > utcnow.as_datetime()
+        assert utcnow.as_protobuf("+1s").seconds == 1
+        assert utcnow.as_protobuf("+1s").nanos == 0
+        assert utcnow.as_protobuf("-1s").seconds == -1
+        assert utcnow.unixtime(utcnow.as_protobuf("+10s")) == 10.0
+        assert utcnow.unixtime(utcnow.as_protobuf("+24h")) == 86400.0
+        assert utcnow.unixtime(utcnow.as_protobuf("-10s")) == -10
+        assert utcnow.rfc3339_timestamp(utcnow.as_protobuf("-10s")) == "1969-12-31T23:59:50.000000Z"
+        assert utcnow.rfc3339_timestamp(utcnow.as_protobuf("-10s")) < utcnow.rfc3339_timestamp()
+        assert utcnow.unixtime(utcnow.as_protobuf("-10s")) < utcnow.unixtime()
+        assert utcnow.rfc3339_timestamp(utcnow.as_protobuf("+1.123987s")) == "1970-01-01T00:00:01.123987Z"
+        assert utcnow.rfc3339_timestamp(utcnow.as_protobuf("-1.123987s")) == "1969-12-31T23:59:58.876013Z"
+        assert utcnow.rfc3339_timestamp(utcnow.as_protobuf("-0.4711s")) == "1969-12-31T23:59:59.528900Z"

--- a/tests/test_now.py
+++ b/tests/test_now.py
@@ -25,6 +25,19 @@ def test_now_datetime() -> None:
     assert a <= b <= c <= d <= e <= f
 
 
+def test_now_protobuf() -> None:
+    import utcnow
+
+    a = utcnow.as_unixtime(utcnow.as_protobuf())
+    b = utcnow.as_unixtime(utcnow.as_protobuf())
+    c = utcnow.as_unixtime(utcnow.as_protobuf())
+    d = utcnow.as_unixtime(utcnow.as_protobuf())
+    e = utcnow.as_unixtime(utcnow.as_protobuf())
+    f = utcnow.as_unixtime(utcnow.as_protobuf())
+
+    assert a <= b <= c <= d <= e <= f
+
+
 def test_now_list_string() -> None:
     import utcnow
 

--- a/tests/test_protobuf.py
+++ b/tests/test_protobuf.py
@@ -59,6 +59,7 @@ def test_protobuf_values(value: Timestamp, expected_output: str, expect_error: b
     assert utcnow.utcnow(utcnow.as_datetime(value)) == utcnow.utcnow(utcnow.as_datetime(expected_output))
     assert utcnow.utcnow(utcnow.as_datetime(value).replace(tzinfo=None)) == expected_output
     assert utcnow.as_string(utcnow.utcnow(utcnow.as_datetime(value))) == expected_output
+    assert utcnow.as_string(utcnow.as_protobuf(value).SerializeToString()) == expected_output
 
     value2 = utcnow.as_protobuf(value)
     assert round(value2.seconds + value2.nanos * 1e-9, 9) == round(value.seconds + value.nanos * 1e-9, 9)
@@ -68,3 +69,10 @@ def test_protobuf_values(value: Timestamp, expected_output: str, expect_error: b
     assert round(message.seconds + message.nanos * 1e-9, 9) == round(value.seconds + value.nanos * 1e-9, 9)
     assert utcnow.as_string(message) == expected_output
     assert message == utcnow.as_protobuf(value)
+
+
+def test_from_protobuf_binary() -> None:
+    import utcnow
+
+    protobuf_msg_binary = b"\x08\xc4\xec\xbc\x9c\x06\x10\xa0\xa1\xb0Q"
+    assert utcnow.get(protobuf_msg_binary) == "2022-12-06T12:32:04.170660Z"

--- a/tests/test_protobuf.py
+++ b/tests/test_protobuf.py
@@ -59,9 +59,12 @@ def test_protobuf_values(value: Timestamp, expected_output: str, expect_error: b
     assert utcnow.utcnow(utcnow.as_datetime(value)) == utcnow.utcnow(utcnow.as_datetime(expected_output))
     assert utcnow.utcnow(utcnow.as_datetime(value).replace(tzinfo=None)) == expected_output
     assert utcnow.as_string(utcnow.utcnow(utcnow.as_datetime(value))) == expected_output
-    assert utcnow.as_protobuf(value) == value
+
+    value2 = utcnow.as_protobuf(value)
+    assert round(value2.seconds + value2.nanos * 1e-9, 9) == round(value.seconds + value.nanos * 1e-9, 9)
 
     message = Timestamp()
     message.FromJsonString(utcnow.as_string(value))
     assert round(message.seconds + message.nanos * 1e-9, 9) == round(value.seconds + value.nanos * 1e-9, 9)
     assert utcnow.as_string(message) == expected_output
+    assert message == utcnow.as_protobuf(value)

--- a/tests/test_protobuf.py
+++ b/tests/test_protobuf.py
@@ -1,0 +1,67 @@
+import datetime
+
+import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+
+
+def protobuf_timestamp_from_json_string(json_string: str) -> Timestamp:
+    """Convert a JSON string (RFC3339) to a protobuf Timestamp."""
+    message = Timestamp()
+    message.FromJsonString(json_string)
+    return message
+
+
+@pytest.mark.parametrize(
+    "value, expected_output, expect_error",
+    [
+        (Timestamp(), "1970-01-01T00:00:00.000000Z", False),
+        (Timestamp(nanos=1000), "1970-01-01T00:00:00.000001Z", False),
+        (Timestamp(nanos=1000), "1970-01-01T00:00:00.000001Z", False),
+        (Timestamp(nanos=10000000), "1970-01-01T00:00:00.010000Z", False),
+        (Timestamp(seconds=1), "1970-01-01T00:00:01.000000Z", False),
+        (Timestamp(seconds=1338), "1970-01-01T00:22:18.000000Z", False),
+        (Timestamp(seconds=14792, nanos=540000000), "1970-01-01T04:06:32.540000Z", False),
+        (Timestamp(nanos=109000), "1970-01-01T00:00:00.000109Z", False),
+        (Timestamp(seconds=1614300199, nanos=462145000), "2021-02-26T00:43:19.462145Z", False),
+        (Timestamp(seconds=1614300199), "2021-02-26T00:43:19.000000Z", False),
+        (Timestamp(nanos=991900000), "1970-01-01T00:00:00.991900Z", False),
+        (Timestamp(seconds=-1), "1969-12-31T23:59:59.000000Z", False),
+        (Timestamp(nanos=-109000), "1969-12-31T23:59:59.999891Z", False),
+        (Timestamp(seconds=-1614300199, nanos=-462145000), "1918-11-05T23:16:40.537855Z", False),
+        (Timestamp(seconds=-1614300199), "1918-11-05T23:16:41.000000Z", False),
+        (Timestamp(nanos=-991900000), "1969-12-31T23:59:59.008100Z", False),
+    ],
+)
+def test_protobuf_values(value: Timestamp, expected_output: str, expect_error: bool) -> None:
+    import utcnow
+
+    try:
+        assert isinstance(utcnow.as_string(value), str)
+        assert isinstance(utcnow.as_datetime(value), datetime.datetime)
+        assert isinstance(utcnow.as_unixtime(value), (float, int))
+        assert isinstance(utcnow.as_protobuf(value), Timestamp)
+        if expect_error:
+            assert False
+    except Exception:
+        if not expect_error:
+            raise
+        if not expect_error:
+            # unreachable
+            assert False
+
+        assert True
+        return
+
+    assert utcnow.as_string(value) == expected_output
+    assert utcnow.as_string(expected_output) == expected_output
+    assert utcnow.as_string(expected_output) == utcnow.as_string(expected_output)
+    assert utcnow.as_datetime(value) == utcnow.as_datetime(expected_output)
+    assert utcnow.utcnow(utcnow.as_datetime(value)) == utcnow.utcnow(utcnow.as_datetime(expected_output))
+    assert utcnow.utcnow(utcnow.as_datetime(value).replace(tzinfo=None)) == expected_output
+    assert utcnow.as_string(utcnow.utcnow(utcnow.as_datetime(value))) == expected_output
+    assert utcnow.as_protobuf(value) == value
+
+    message = Timestamp()
+    message.FromJsonString(utcnow.as_string(value))
+    assert round(message.seconds + message.nanos * 1e-9, 9) == round(value.seconds + value.nanos * 1e-9, 9)
+    assert utcnow.as_string(message) == expected_output

--- a/tests/test_rfc3799.py
+++ b/tests/test_rfc3799.py
@@ -1,6 +1,7 @@
 import datetime
 
 import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
 
 
 @pytest.mark.parametrize(
@@ -51,6 +52,7 @@ def test_to_string_values(value: str, expected_output: str, expect_error: bool) 
         assert isinstance(utcnow.as_string(value), str)
         assert isinstance(utcnow.as_datetime(value), datetime.datetime)
         assert isinstance(utcnow.as_unixtime(value), (float, int))
+        assert isinstance(utcnow.as_protobuf(value), Timestamp)
         if expect_error:
             assert False
     except Exception:

--- a/tests/test_unixtime.py
+++ b/tests/test_unixtime.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from typing import Union
 
 import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
 
 
 @pytest.mark.parametrize(
@@ -84,6 +85,7 @@ def test_unixtime_values(value: Union[int, float, str, Decimal], expected_output
         assert isinstance(utcnow.as_string(value), str)
         assert isinstance(utcnow.as_datetime(value), datetime.datetime)
         assert isinstance(utcnow.as_unixtime(value), (float, int))
+        assert isinstance(utcnow.as_protobuf(value), Timestamp)
         if expect_error:
             assert False
     except Exception:

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -188,6 +188,9 @@ def _timestamp_to_unixtime(value: str_) -> float:
 def _unixtime_to_protobuf(unixtime_value: Union[int, float]) -> TimestampProtobufMessage:
     seconds = int(unixtime_value)
     nanos = round(int((unixtime_value - seconds) * 1e6)) * 1000
+    if nanos < 0:
+        seconds -= 1
+        nanos += 1_000_000_000
     return TimestampProtobufMessage(
         seconds=seconds,
         nanos=nanos,
@@ -323,6 +326,9 @@ class utcnow_(_baseclass):
             unixtime_value = time_.time() + modifier
             seconds = int(unixtime_value)
             nanos = round(int((unixtime_value - seconds) * 1e6)) * 1000
+            if nanos < 0:
+                seconds -= 1
+                nanos += 1_000_000_000
             return TimestampProtobufMessage(
                 seconds=seconds,
                 nanos=nanos,

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -63,18 +63,24 @@ def _is_numeric(value: str_) -> bool:
 
 
 def _init_modifier(
-    value: Union[str_, datetime_, object, int, float, Decimal, Real, TimestampProtobufMessage],
+    value: Union[str_, datetime_, object, int, float, Decimal, Real, bytes, TimestampProtobufMessage],
     modifier: Optional[Union[str_, int, float]] = 0,
 ) -> Tuple[Union[str_, datetime_, object, int, float, Decimal, Real], Union[int, float]]:
     if isinstance(value, TimestampProtobufMessage):
-        return _init_modifier_lru(value.seconds + round(value.nanos * 1e-9, 9), modifier)
+        value = value.seconds + round(value.nanos * 1e-9, 9)
     return _init_modifier_lru(value, modifier)
 
 
 @functools.lru_cache(maxsize=128, typed=True)
 def _init_modifier_lru(
-    value: Union[str_, datetime_, object, int, float, Decimal, Real], modifier: Optional[Union[str_, int, float]] = 0
+    value: Union[str_, datetime_, object, int, bytes, float, Decimal, Real],
+    modifier: Optional[Union[str_, int, float]] = 0,
 ) -> Tuple[Union[str_, datetime_, object, int, float, Decimal, Real], Union[int, float]]:
+    if isinstance(value, bytes):
+        value_ = TimestampProtobufMessage()
+        value_.MergeFromString(value)
+        value = value_.seconds + round(value_.nanos * 1e-9, 9)
+
     if (
         value is not _SENTINEL
         and value

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -13,6 +13,7 @@ from numbers import Real
 from typing import Any, Dict, Optional, Tuple, Type, Union, cast
 
 from .__version_data__ import __version__, __version_info__
+from .protobuf import TimestampProtobufMessage
 
 str_ = str
 
@@ -61,8 +62,17 @@ def _is_numeric(value: str_) -> bool:
     return False
 
 
-@functools.lru_cache(maxsize=128, typed=True)
 def _init_modifier(
+    value: Union[str_, datetime_, object, int, float, Decimal, Real, TimestampProtobufMessage],
+    modifier: Optional[Union[str_, int, float]] = 0,
+) -> Tuple[Union[str_, datetime_, object, int, float, Decimal, Real], Union[int, float]]:
+    if isinstance(value, TimestampProtobufMessage):
+        return _init_modifier_lru(value.seconds + round(value.nanos * 1e-9, 9), modifier)
+    return _init_modifier_lru(value, modifier)
+
+
+@functools.lru_cache(maxsize=128, typed=True)
+def _init_modifier_lru(
     value: Union[str_, datetime_, object, int, float, Decimal, Real], modifier: Optional[Union[str_, int, float]] = 0
 ) -> Tuple[Union[str_, datetime_, object, int, float, Decimal, Real], Union[int, float]]:
     if (
@@ -172,6 +182,16 @@ def _timestamp_to_datetime(value: str_) -> datetime_:
 @functools.lru_cache(maxsize=128)
 def _timestamp_to_unixtime(value: str_) -> float:
     return _timestamp_to_datetime(value).timestamp()
+
+
+@functools.lru_cache(maxsize=128)
+def _unixtime_to_protobuf(unixtime_value: Union[int, float]) -> TimestampProtobufMessage:
+    seconds = int(unixtime_value)
+    nanos = round(int((unixtime_value - seconds) * 1e6)) * 1000
+    return TimestampProtobufMessage(
+        seconds=seconds,
+        nanos=nanos,
+    )
 
 
 @functools.lru_cache(maxsize=128)
@@ -292,6 +312,24 @@ class utcnow_(_baseclass):
             return time_.time() + modifier
         return _timestamp_to_unixtime(value) + modifier
 
+    def as_protobuf(
+        self,
+        value: Union[str_, datetime_, object, int, float, Decimal, Real] = _SENTINEL,
+        modifier: Optional[Union[str_, int, float]] = 0,
+    ) -> TimestampProtobufMessage:
+        value, modifier = _init_modifier(value, modifier)
+
+        if value is _SENTINEL:
+            unixtime_value = time_.time() + modifier
+            seconds = int(unixtime_value)
+            nanos = round(int((unixtime_value - seconds) * 1e6)) * 1000
+            return TimestampProtobufMessage(
+                seconds=seconds,
+                nanos=nanos,
+            )
+
+        return _unixtime_to_protobuf(_timestamp_to_unixtime(value) + modifier)
+
     def timediff(
         self,
         begin: Union[str_, datetime_, object, int, float, Decimal, Real],
@@ -398,6 +436,26 @@ class utcnow_(_baseclass):
     timestamp = as_unixtime
     ut = as_unixtime
     ts = as_unixtime
+
+    as_proto = as_protobuf
+    as_protobuf_timestamp = as_protobuf
+    as_proto_timestamp = as_protobuf
+    as_pb = as_protobuf
+    to_protobuf = as_protobuf
+    to_proto = as_protobuf
+    to_protobuf_timestamp = as_protobuf
+    to_proto_timestamp = as_protobuf
+    to_pb = as_protobuf
+    get_protobuf = as_protobuf
+    get_proto = as_protobuf
+    get_protobuf_timestamp = as_protobuf
+    get_proto_timestamp = as_protobuf
+    get_pb = as_protobuf
+    protobuf = as_protobuf
+    proto = as_protobuf
+    protobuf_timestamp = as_protobuf
+    proto_timestamp = as_protobuf
+    pb = as_protobuf
 
     time_diff = timediff
     diff = timediff
@@ -518,6 +576,27 @@ time = as_unixtime
 timestamp = as_unixtime
 ut = as_unixtime
 ts = as_unixtime
+
+as_protobuf = _module_value.as_protobuf
+as_proto = as_protobuf
+as_protobuf_timestamp = as_protobuf
+as_proto_timestamp = as_protobuf
+as_pb = as_protobuf
+to_protobuf = as_protobuf
+to_proto = as_protobuf
+to_protobuf_timestamp = as_protobuf
+to_proto_timestamp = as_protobuf
+to_pb = as_protobuf
+get_protobuf = as_protobuf
+get_proto = as_protobuf
+get_protobuf_timestamp = as_protobuf
+get_proto_timestamp = as_protobuf
+get_pb = as_protobuf
+protobuf = as_protobuf
+proto = as_protobuf
+protobuf_timestamp = as_protobuf
+proto_timestamp = as_protobuf
+pb = as_protobuf
 
 timediff = _module_value.timediff
 time_diff = timediff

--- a/utcnow/protobuf/__init__.py
+++ b/utcnow/protobuf/__init__.py
@@ -1,0 +1,45 @@
+import sys
+from typing import Any
+
+try:
+    from google.protobuf.message import Message as GenericProtobufMessage  # noqa
+except Exception:  # pragma: no cover
+
+    class _GenericProtobufMessage(object):
+        pass
+
+    this_module = sys.modules[__name__]
+    setattr(this_module, "GenericProtobufMessage", _GenericProtobufMessage)
+
+try:
+    from google.protobuf.timestamp_pb2 import Timestamp  # noqa
+
+    TimestampProtobufMessage = Timestamp
+except Exception:  # pragma: no cover
+
+    class _TimestampProtobufMessage(object):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise Exception("google.protobuf package not installed")
+
+        def SerializeToString(self, *args: Any, **kwargs: Any) -> None:
+            raise Exception("google.protobuf package not installed")
+
+        def FromString(self, *args: Any, **kwargs: Any) -> None:
+            raise Exception("google.protobuf package not installed")
+
+        def ParseFromString(self, *args: Any, **kwargs: Any) -> None:
+            raise Exception("google.protobuf package not installed")
+
+        def MergeFromString(self, *args: Any, **kwargs: Any) -> None:
+            raise Exception("google.protobuf package not installed")
+
+    this_module = sys.modules[__name__]
+    setattr(this_module, "Timestamp", _TimestampProtobufMessage)
+    setattr(this_module, "TimestampProtobufMessage", _TimestampProtobufMessage)
+
+
+__all__ = [
+    "GenericProtobufMessage",
+    "Timestamp",
+    "TimestampProtobufMessage",
+]


### PR DESCRIPTION
### Converting from Protocol Buffers message

Possible to transform a value encoded as a `google.protobuf.Timestamp` protobuf message in the same way you would from any other value.

```python
# Using a google.protobuf.Timestamp message as input to utcnow
import utcnow
from google.protobuf.timestamp_pb2 import Timestamp
msg = Timestamp(seconds=1670329924, nanos=170660000)
result = utcnow.get(msg)
# "2022-12-06T12:32:04.170660Z"
```

```python
# Using the binary data from a google.protobuf.Timestamp message
import utcnow
protobuf_msg_binary = b"\x08\xc4\xec\xbc\x9c\x06\x10\xa0\xa1\xb0Q"
result = utcnow.get(protobuf_msg_binary)
# "2022-12-06T12:32:04.170660Z"
```

You can also generate a new `google.protobuf.Timestamp` message using `utcnow.as_protobuf()`

```python
import utcnow
msg = utcnow.as_protobuf("1984-08-01 22:30:47.234003Z")
# <class 'google.protobuf.timestamp_pb2.Timestamp'>
# · seconds: 460247447
# · nanos: 234003000
```

Note that the `protobuf` package has to be installed to make use of the above functionality. For convenience, it's also possible to install `utcnow` with `protobuf` support using the `protobuf` extras.

```
$ pip install utcnow[protobuf]
```
