### PR TITLE
Updates interactions with the datetime library to avoid using deprecated functions datetime.utcnow() and datetime.utcfromtimestamp()

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,8 +344,10 @@ utcnow.utcnow()
 # 3. str(utcnow.utcnow)
 # 4. utcnow.get()
 # 5. utcnow.utcnow.get()
-# 6. datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-# 7. datetime.datetime.utcnow().isoformat() + "Z"
+# 6. datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+# 7. datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+# 8. datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+# 9. datetime.datetime.utcnow().isoformat(timespec="microseconds") + "Z"
 ```
 
 ```python
@@ -365,7 +367,8 @@ utcnow.as_datetime()
 
 # this is merely a convinience, as the same value would be returned by both:
 # 1. utcnow.as_datetime()
-# 2. datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+# 2. datetime.datetime.now(datetime.timezone.utc)
+# 3. datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
 ```
 
 ```python
@@ -434,7 +437,7 @@ $ pip install utcnow[protobuf]
 
 Not as common, but every now and then you might need to get the date part from a timestamp (or for example today's date), to use in some string concatenation, S3 object keys and what not.
 
-There's the long away around it, by generating a timestamp with `utcnow.get()` and then just keeping the first 10 characters of the timestamp – that's the date – `YYYY-MM-DD`. You could even use `datetime` and go `datetime.datetime.utcnow().date().isoformat()`, but it's not super clean.
+There's the long away around it, by generating a timestamp with `utcnow.get()` and then just keeping the first 10 characters of the timestamp – that's the date – `YYYY-MM-DD`. You could even use `datetime` and go `datetime.datetime.now(datetime.timezone.utc).date().isoformat()`, but it's not super clean.
 
 `utcnow` comes with a wrapper function `utcnow.as_date_string(value)` to fetch just the date part based on the input value's UTC timestamp. Note that the date string that is returned does not include timezone information.
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -133,8 +133,11 @@ def test_dates(value: str, expect_error: bool) -> None:
 
 
 def test_as_date_string() -> None:
-    date_today_0 = datetime.datetime.utcnow().date().isoformat()
-    assert utcnow.get_today() == date_today_0 or utcnow.get_today() == datetime.datetime.utcnow().date().isoformat()
+    date_today_0 = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+    assert (
+        utcnow.get_today() == date_today_0
+        or utcnow.get_today() == datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+    )
 
     assert utcnow.as_date_string("2022-04-04") == "2022-04-04"
     assert utcnow.as_date_string("2021-01-02T00:00:00.04000Z") == "2021-01-02"
@@ -144,11 +147,11 @@ def test_as_date_string() -> None:
 
     assert (
         utcnow.get_today(tz="UTC") == date_today_0
-        or utcnow.get_today(tz="UTC") == datetime.datetime.utcnow().date().isoformat()
+        or utcnow.get_today(tz="UTC") == datetime.datetime.now(datetime.timezone.utc).date().isoformat()
     )
     assert (
         utcnow.get_today(tz=datetime.timezone.utc) == date_today_0
-        or utcnow.get_today(tz=datetime.timezone.utc) == datetime.datetime.utcnow().date().isoformat()
+        or utcnow.get_today(tz=datetime.timezone.utc) == datetime.datetime.now(datetime.timezone.utc).date().isoformat()
     )
 
     assert utcnow.get_today(tz=datetime.timezone(datetime.timedelta(hours=24, microseconds=-1))) != utcnow.get_today()

--- a/tests/test_lrucache.py
+++ b/tests/test_lrucache.py
@@ -724,7 +724,7 @@ def test_cache_hits_with_uniques_loop() -> None:
     assert hits_miss_currsize(_transform_value) == ((call_count - 1) * 2, call_count * 2 + 2, 128)
     assert hits_miss_currsize(_timestamp_to_datetime) == (0, 0, 0)
 
-    t_dt = datetime.datetime.utcnow()
+    t_dt = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
     for _ in range(call_count):
         values.add(utcnow.get(t_dt))
         time.sleep(0.00001)
@@ -735,12 +735,23 @@ def test_cache_hits_with_uniques_loop() -> None:
     assert hits_miss_currsize(_transform_value) == ((call_count - 1) * 3, call_count * 2 + 3, 128)
     assert hits_miss_currsize(_timestamp_to_datetime) == (0, 0, 0)
 
+    t_dt = datetime.datetime.now(datetime.timezone.utc)
     for _ in range(call_count):
-        values.add(utcnow.get(datetime.datetime.utcnow()))
+        values.add(utcnow.get(t_dt))
         time.sleep(0.00001)
 
-    assert len(values) == call_count * 3 + 3
+    assert len(values) == call_count * 2 + 4
 
     assert hits_miss_currsize(_is_numeric) == (0, call_count + 1, call_count + 1)
-    assert hits_miss_currsize(_transform_value) == ((call_count - 1) * 3, call_count * 3 + 3, 128)
+    assert hits_miss_currsize(_transform_value) == ((call_count - 1) * 4, call_count * 2 + 4, 128)
+    assert hits_miss_currsize(_timestamp_to_datetime) == (0, 0, 0)
+
+    for _ in range(call_count):
+        values.add(utcnow.get(datetime.datetime.now(datetime.timezone.utc)))
+        time.sleep(0.00001)
+
+    assert len(values) == call_count * 3 + 4
+
+    assert hits_miss_currsize(_is_numeric) == (0, call_count + 1, call_count + 1)
+    assert hits_miss_currsize(_transform_value) == ((call_count - 1) * 4, call_count * 3 + 4, 128)
     assert hits_miss_currsize(_timestamp_to_datetime) == (0, 0, 0)

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -130,9 +130,12 @@ def _transform_value(
         if isinstance(value, str_):
             str_value = value.strip()
         elif isinstance(value, (int, float)):
-            return datetime_.utcfromtimestamp(value).isoformat(timespec="microseconds") + "Z"
+            return datetime_.fromtimestamp(value, tz=UTC).isoformat(timespec="microseconds").replace("+00:00", "") + "Z"
         elif isinstance(value, (Decimal, Real)):
-            str_value = datetime_.utcfromtimestamp(float(value)).isoformat(timespec="microseconds") + "Z"
+            str_value = (
+                datetime_.fromtimestamp(float(value), tz=UTC).isoformat(timespec="microseconds").replace("+00:00", "")
+                + "Z"
+            )
         else:
             str_value = str_(value).strip()
 
@@ -145,7 +148,12 @@ def _transform_value(
             and str_value.count("-") <= 1
             and _is_numeric(str_value)
         ):
-            str_value = datetime_.utcfromtimestamp(float(str_value)).isoformat(timespec="microseconds") + "Z"
+            str_value = (
+                datetime_.fromtimestamp(float(str_value), tz=UTC)
+                .isoformat(timespec="microseconds")
+                .replace("+00:00", "")
+                + "Z"
+            )
     except Exception:
         raise ValueError(f"The input value '{value}' (type: {value.__class__}) does not match allowed input formats")
 
@@ -266,8 +274,8 @@ class _baseclass(metaclass=_metaclass):
 
         if value is _SENTINEL:
             return (
-                datetime_.utcnow() if not modifier else datetime_.utcnow() + timedelta_(seconds=modifier)
-            ).isoformat(timespec="microseconds") + "Z"
+                datetime_.now(UTC) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier)
+            ).isoformat(timespec="microseconds").replace("+00:00", "") + "Z"
         return _transform_value(value) if not modifier else _transform_value(_timestamp_to_unixtime(value) + modifier)
 
 
@@ -278,10 +286,10 @@ class now_(_baseclass):
         return result
 
     def __str__(self) -> str_:
-        return datetime_.utcnow().isoformat(timespec="microseconds") + "Z"
+        return datetime_.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "") + "Z"
 
     def __repr__(self) -> str_:
-        return datetime_.utcnow().isoformat(timespec="microseconds") + "Z"
+        return datetime_.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "") + "Z"
 
 
 class utcnow_(_baseclass):
@@ -301,8 +309,8 @@ class utcnow_(_baseclass):
 
         if value is _SENTINEL:
             return (
-                datetime_.utcnow() if not modifier else datetime_.utcnow() + timedelta_(seconds=modifier)
-            ).isoformat(timespec="microseconds") + "Z"
+                datetime_.now(UTC) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier)
+            ).isoformat(timespec="microseconds").replace("+00:00", "") + "Z"
         return _transform_value(value) if not modifier else _transform_value(_timestamp_to_unixtime(value) + modifier)
 
     def as_datetime(
@@ -313,7 +321,7 @@ class utcnow_(_baseclass):
         value, modifier = _init_modifier(value, modifier)
 
         if value is _SENTINEL:
-            # 'datetime.datetime.now(UTC)' is faster than 'datetime.datetime.utcnow().replace(tzinfo=UTC)'
+            # 'datetime.datetime.now(UTC)' is faster than (deprecated) 'datetime.datetime.utcnow().replace(tzinfo=UTC)'
             return datetime_.now(UTC) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier)
         return _timestamp_to_datetime(value) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier)
 

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -130,11 +130,10 @@ def _transform_value(
         if isinstance(value, str_):
             str_value = value.strip()
         elif isinstance(value, (int, float)):
-            return datetime_.fromtimestamp(value, tz=UTC).isoformat(timespec="microseconds").replace("+00:00", "") + "Z"
+            return datetime_.fromtimestamp(value, tz=UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
         elif isinstance(value, (Decimal, Real)):
             str_value = (
-                datetime_.fromtimestamp(float(value), tz=UTC).isoformat(timespec="microseconds").replace("+00:00", "")
-                + "Z"
+                datetime_.fromtimestamp(float(value), tz=UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
             )
         else:
             str_value = str_(value).strip()
@@ -151,8 +150,7 @@ def _transform_value(
             str_value = (
                 datetime_.fromtimestamp(float(str_value), tz=UTC)
                 .isoformat(timespec="microseconds")
-                .replace("+00:00", "")
-                + "Z"
+                .replace("+00:00", "Z")
             )
     except Exception:
         raise ValueError(f"The input value '{value}' (type: {value.__class__}) does not match allowed input formats")
@@ -274,8 +272,10 @@ class _baseclass(metaclass=_metaclass):
 
         if value is _SENTINEL:
             return (
-                datetime_.now(UTC) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier)
-            ).isoformat(timespec="microseconds").replace("+00:00", "") + "Z"
+                (datetime_.now(UTC) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier))
+                .isoformat(timespec="microseconds")
+                .replace("+00:00", "Z")
+            )
         return _transform_value(value) if not modifier else _transform_value(_timestamp_to_unixtime(value) + modifier)
 
 
@@ -286,10 +286,10 @@ class now_(_baseclass):
         return result
 
     def __str__(self) -> str_:
-        return datetime_.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "") + "Z"
+        return datetime_.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
 
     def __repr__(self) -> str_:
-        return datetime_.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "") + "Z"
+        return datetime_.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
 
 
 class utcnow_(_baseclass):
@@ -309,8 +309,10 @@ class utcnow_(_baseclass):
 
         if value is _SENTINEL:
             return (
-                datetime_.now(UTC) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier)
-            ).isoformat(timespec="microseconds").replace("+00:00", "") + "Z"
+                (datetime_.now(UTC) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier))
+                .isoformat(timespec="microseconds")
+                .replace("+00:00", "Z")
+            )
         return _transform_value(value) if not modifier else _transform_value(_timestamp_to_unixtime(value) + modifier)
 
     def as_datetime(


### PR DESCRIPTION
There are no changes in the API of this library and all results will be returned as previously. This change is only to internally provide fixes for the deprecation warnings.

---

Fixes for the following deprecation warnings since Python 3.12:

* DeprecationWarning: `datetime.utcnow()` is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: `datetime.now(datetime.UTC)`
* DeprecationWarning: `datetime.utcfromtimestamp()` is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: `datetime.fromtimestamp(timestamp, datetime.UTC)`.

---

The now deprecated `datetime.datetime.utcnow()` function produced a `datetime` object with `tzinfo` set to `None`.

`datetime.datetime.utcnow()` is equivalent to `datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)`

Internally, this `utcnow` library will now instead initialize `datetime` objects with UTC default `tzinfo`, and instead replace the `"+00:00"` suffix with `"Z"` when converting to string using `datetime`'s `.isoformat()` function. 

The returned values from this library remains the same as previously.