### PR TITLE
Inline API documentation + ModuleType refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ utcnow.get("1989-12-13 08:35 UTC")
 > "Why UTC? It's not even a timezone for our markets."
 
 > **Devs (and wikipedia):**
-> "_Coordinated Universal Time_ or _Universal Time Coordinated_, UTC for short, is still currently _the primary time standard_ and is not affected by daylight saving time, which is usually not something that servers or software developers would want to work around."
+> "*Coordinated Universal Time* or *Universal Time Coordinated*, UTC for short, is still currently *the primary time standard* and is not affected by daylight saving time, which is usually not something that servers or software developers would want to work around."
 >
 > "It's pretty simple – modern internet applications shouldn't use any other timezone in their databases, logs, API:s or other computer to computer interfaces."
 
@@ -81,7 +81,7 @@ Good timestamps and UTC – really no wild and crazy opinions. Generailly this l
 
 **The following ruleset are applied to timestamps returned by `utcnow` when requesting a string based format:**
 
-* Timestamps follow RFC 3339 (Date and Time on the Internet: Timestamps): https://tools.ietf.org/html/rfc3339.
+* Timestamps follow RFC 3339 (Date and Time on the Internet: Timestamps): <https://tools.ietf.org/html/rfc3339>.
 * Timestamps are converted to UTC timezone which we'll note in the timestamp with the "Z" syntax instead of the also accepted "+00:00". "Z" stands for UTC+0 or "Zulu time" and refers to the zone description of zero hours.
 * Timestamps are expressed as a date-time, including the full date (the "T" between the date and the time is optional in RFC 3339 (but not in ISO 8601) and usually describes the beginning of the time part.
 * Timestamps are 27 characters long in the format: "YYYY-MM-DDTHH:mm:ss.ffffffZ". 4 digit year, 2 digit month, 2 digit days. "T", 2 digit hours, 2 digit minutes, 2 digit seconds, 6 fractional second digits (microseconds -> nanoseconds), followed by the timezone identifier for UTC: "Z".
@@ -89,7 +89,6 @@ Good timestamps and UTC – really no wild and crazy opinions. Generailly this l
 `utcnow` is defined to return timestamps with 6 fractional second digits, which means timestamps down to the microsecond level. Having a six-digit fraction of a second is currently the most common way that timestamps are shown at this date.
 
 When using a fixed length return value for string based timestamps it'll even make the returned strings comparable to each other.
-
 
 ### Where to use this – for what kind of applications or interfaces
 
@@ -101,15 +100,14 @@ If your work require a complex mix and match back and forth using different time
 
 Note that this library is built with backend developers in mind and while these date-time formatted timestamps are more readable than unix timestamps, they still usually shouldn't be used within user interfaces, however since these format of timestamps are so common basically any library will be able to convert back and forth into whatever your human users would expect, to improve readability – useful for frontend applications, app user interfaces, etc. Also, using a standard like this, the frontend devs won't banish you for changing formatting of timestamps within API responses across different services.
 
-
 ## Supported input values for timestamp conversion
 
 This library aims at going for simplicity by being explicit about the choices allowed to make. `utcnow` however allows the conversion methods to be called with the following kind of argument values:
+
 * RFC 3339 compliant strings, which at the very least must include the full date, but could omit the time part of a date-time, leaving only the date, or by not including the seconds, microseconds or even laving out the timezone information – `utcnow` supports all of the use-cases of RFC 3339 inputs and then converts the input into an even more complete RFC 3339 timestamp in UTC timezone.
 * The most common format for handling dates and datetimes in Python, the builtin `datetime.datetime` object values (both timezone aware values, as well as values that aren't timezone aware, as for which we'll assume UTC).
 * Also supporting object values from other commonly used libraries, such as `arrow`.
 * As a bonus – Unix time, mainly for convinience (`time.time()`) (we have many names for the things we love: epoch time, posix time, seconds since epoch, 2038-bug on 32-bit unsigned ints to time-travel back to the first radio-transmission across the atlantic, there will be movies about this ).
-
 
 ## Can also be used on the command-line
 
@@ -147,7 +145,6 @@ code ~$ utcnow "2022-02-28 10:10:59.100+02:00" "1984-08-01 15:00"
     utcnow --version                 | short: -v   show installed version
 ```
 
-
 ## A neat side-effect of defaulted string output – comparison as strings
 
 > If date and time components are ordered from least precise to most precise, then a useful property is achieved.  Assuming that the time zones of the dates and times are the same (e.g., all in UTC), expressed using the same string (e.g., all "Z" or all "+00:00"), and all times have the same number of fractional second digits, then the date and time strings may be sorted as strings and a time-ordered sequence will result. he presence of optional punctuation would violate this characteristic.
@@ -163,7 +160,6 @@ Here follows a few examples of the problems with having to work with mismatching
 "2022-08-01T13:51Z"                    >  "2022-08-01T13:51:30.000000Z"          # True  😵
 ```
 
-
 *Using `utcnow` on the same set of timestamps, which returns a string value for comparison.*
 
 ```python
@@ -175,7 +171,6 @@ utcnow("2022-08-01T14:00:10+01:00")    >  utcnow("2022-08-01T13:51:30.000000Z") 
 utcnow("2022-08-01T13:51Z")            >  utcnow("2022-08-01T13:51:30.000000Z")  # False 😻
 ```
 
-
 *This shown the returned values from the `utcnow` calls, and for what the comparisons is actually evaluated on.*
 
 ```python
@@ -184,7 +179,6 @@ utcnow("2022-08-01T13:51Z")            >  utcnow("2022-08-01T13:51:30.000000Z") 
 "2022-08-01T13:00:10.000000Z"          >  "2022-08-01T13:51:30.000000Z"          # False 🥇
 "2022-08-01T13:51:00.000000Z"          >  "2022-08-01T13:51:30.000000Z"          # False 😻
 ```
-
 
 ## Transformation examples
 
@@ -225,17 +219,18 @@ utcnow.get("2021-02-28 10:10:59.123987Z")       # "2021-02-28T10:10:59.123987Z"
 utcnow.get("2021-02-28 10:10:59.123987 UTC")    # "2021-02-28T10:10:59.123987Z"
 ```
 
-
 ## Installation
+
 Like you would install any other Python package, use `pip`, `poetry`, `pipenv` or your weapon of choice.
+
 ```
-$ pip install utcnow
+pip install utcnow
 ```
 
 To install with Protocol Buffers support, specify the `protobuf` extras.
 
 ```
-$ pip install utcnow[protobuf]
+pip install utcnow[protobuf]
 ```
 
 ## Usage and examples
@@ -430,7 +425,7 @@ msg = utcnow.as_protobuf("1984-08-01 22:30:47.234003Z")
 Note that the `protobuf` package has to be installed to make use of the above functionality. For convenience, it's also possible to install `utcnow` with `protobuf` support using the `protobuf` extras.
 
 ```
-$ pip install utcnow[protobuf]
+pip install utcnow[protobuf]
 ```
 
 ### Get the date part as a string from a timestamp
@@ -449,7 +444,7 @@ utcnow.as_date_string(timestamp)
 # "2022-04-05"
 ```
 
-Bonus 🎉🎉 – calling the `utcnow.as_date_string()` function without arguments will return today's date, _based on the current time in UTC_. For some sugar to your code, the same function is also available under the name `utcnow.today()`.
+Bonus 🎉🎉 – calling the `utcnow.as_date_string()` function without arguments will return today's date, *based on the current time in UTC*. For some sugar to your code, the same function is also available under the name `utcnow.today()`.
 
 To get the current date in another timezone use the keyword argument `tz` to the function call. The value for `tz` should be either a `datetime.tzinfo` object or an utcoffset represented as a string (for example "+01:00", "-06:00", etc.).
 
@@ -481,14 +476,27 @@ seconds = utcnow.timediff(begin, end)
 # just divides the number of seconds with the value relative to the unit. If not
 # specified, the default unit "seconds" will be applied.
 
-minutes = utcnow.timediff(begin, end, "minutes")
+seconds = utcnow.timediff(begin, end, "seconds")  # diff in seconds (alias: "s")
+# 16200.0
+
+minutes = utcnow.timediff(begin, end, "minutes")  # diff in minutes (alias: "m")
 # 270.0
 
-hours = utcnow.timediff(begin, end, "hours")
+hours = utcnow.timediff(begin, end, "hours")  # diff in hours (alias: "h")
 # 4.5
 
-days = utcnow.timediff(begin, end, "days")
+days = utcnow.timediff(begin, end, "days")  # diff in days (alias: "d")
 # 0.1875
+
+milliseconds = utcnow.timediff(begin, end, "milliseconds")  # diff in milliseconds (alias: "ms")
+# 162000000.0
+
+milliseconds = utcnow.timediff(begin, end, "microseconds")  # diff in microseconds (alias: "us")
+# 16200000000.0
+
+nanoseconds = utcnow.timediff(begin, end, "nanoseconds")  # diff in nanoseconds (alias: "ns")
+# 16200000000000.0
+
 ```
 
 ```python
@@ -504,15 +512,13 @@ also_the_answer = 1234567890 - 0
 # 1234567890
 ```
 
-
 ## Finally
 
 This is not a fullblown date library at all – it's lightweight, convenient utility package and should mostly just be used to output the date-time timestamp we want and at times convert values from other parts into our fixed length string format `YYYY-MM-DDTHH:mm:ss.ffffffZ` (or as `%Y-%m-%dT%H:%M:%SZ` as if used with `datetime.datetime.strftime` on a naive `datetime` value or a `datetime` value in UTC). Always uses UTC in output and always appends the UTC timezone as a `Z` to the string (instead of using `+00:00`, which a tz-aware `datetime` would do when used with `datetime.isoformat()`).
 
-Use `utcnow` when you need to store date-time timestamps (and also preferably _internet_ date-time timestamps) in any datastore as a string, using them in API responses (JSON responses usually) or when your services are adding timestamps in their log outputs.
+Use `utcnow` when you need to store date-time timestamps (and also preferably *internet* date-time timestamps) in any datastore as a string, using them in API responses (JSON responses usually) or when your services are adding timestamps in their log outputs.
 
-Wether you choose to use this library or anything else, or just specify _this is how we do it_ in a documement, it'll be worth it. It's never too late to start aligning your formatting standards and interfaces.
-
+Wether you choose to use this library or anything else, or just specify *this is how we do it* in a documement, it'll be worth it. It's never too late to start aligning your formatting standards and interfaces.
 
 ## TLDR?
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![MIT License](https://img.shields.io/github/license/kalaspuff/utcnow.svg)](https://github.com/kalaspuff/utcnow/blob/master/LICENSE)
 [![Code coverage](https://codecov.io/gh/kalaspuff/utcnow/branch/master/graph/badge.svg)](https://codecov.io/gh/kalaspuff/utcnow/tree/master/utcnow)
 
-*Timestamps as RFC 3339 (Date & Time on the Internet) formatted strings with conversion functionality from other timestamp formats or for timestamps on other timezones. Additionally converts timestamps from datetime objets and other common date utilities. Follow modern practices when developing API interfaces.*
+*Timestamps as RFC 3339 (Date & Time on the Internet) formatted strings with conversion functionality from other timestamp formats or for timestamps on other timezones. Additionally converts timestamps from datetime objects and other common date utilities. Follow modern practices when developing API interfaces.*
 
-### A library for formatting timestamps as RFC3339
+### A library for formatting timestamps as RFC 3339
 
-* One preferred output format strictly following RFC3339.
+* One preferred output format strictly following RFC 3339.
 * Making it easier to follow common best practices for developers.
 * Tranforming timestamps from (or when needed, to) common interfaces such as unix timestamps, `datetime` objects, `google.protobuf.Timestamp` messages or plain text.
 * Type hinted, battle tested and supporting several versions of Python.

--- a/README.md
+++ b/README.md
@@ -449,17 +449,17 @@ utcnow.as_date_string(timestamp)
 # "2022-04-05"
 ```
 
-Bonus 🎉🎉 – calling the `utcnow.as_date_string()` function without arguments will return today's date, _based on the current time in UTC_. For some sugar to your code, the same function is also available under the name `utcnow.get_today()`.
+Bonus 🎉🎉 – calling the `utcnow.as_date_string()` function without arguments will return today's date, _based on the current time in UTC_. For some sugar to your code, the same function is also available under the name `utcnow.today()`.
 
 To get the current date in another timezone use the keyword argument `tz` to the function call. The value for `tz` should be either a `datetime.tzinfo` object or an utcoffset represented as a string (for example "+01:00", "-06:00", etc.).
 
 ```python
 import utcnow
 
-utcnow.get_today()
+utcnow.today()
 # "2022-04-05" (it's the 5th of April when typing this)
 
-utcnow.get_today(tz="+12:00")
+utcnow.today(tz="+12:00")
 # "2022-04-06" (time in UTC is currently 15:12 - adding 12 hours to that would yield 03:12 tomorrow)
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ warn_return_any = true
 warn_unreachable = true
 
 [tool.flake8]
-ignore = ["E203", "E501", "W503", "E231", "E221"]
+ignore = ["E203", "E501", "W503", "E231", "E221", "E704", "E301", "E302"]
 exclude = ["utcnow.egg-info", ".git", ".mypy_cache", ".pytest_cache", ".venv", ".vscode", "__pycache__", "build", "dist", "tmp"]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ warn_return_any = true
 warn_unreachable = true
 
 [tool.flake8]
-ignore = ["E203", "E501", "W503", "E231", "E221", "E704", "E301", "E302"]
+ignore = ["E203", "E501", "W503", "E231", "E221", "E704", "E301", "E302", "E305"]
 exclude = ["utcnow.egg-info", ".git", ".mypy_cache", ".pytest_cache", ".venv", ".vscode", "__pycache__", "build", "dist", "tmp"]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,5 +107,13 @@ warn_unreachable = true
 ignore = ["E203", "E501", "W503", "E231", "E221", "E704", "E301", "E302", "E305"]
 exclude = ["utcnow.egg-info", ".git", ".mypy_cache", ".pytest_cache", ".venv", ".vscode", "__pycache__", "build", "dist", "tmp"]
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore:Using the 'utcnow[.](get_today)[(][)]' function alias is deprecated. Use the 'utcnow[.]today[(][)]' function instead.:DeprecationWarning:utcnow",
+    "ignore:Using the 'utcnow[.](unixtime)[(][)]' function alias is deprecated. Use the 'utcnow[.]as_unixtime[(][)]' function instead.:DeprecationWarning:utcnow",
+    "ignore:Using the 'utcnow[.](as_string|as_str|as_rfc3339|to_string|to_str|to_rfc3339|get_string|get_str|get_rfc3339|string|rfc3339|str)[(][)]' function alias is deprecated. Use the 'utcnow[.]rfc3339_timestamp[(][)]' function instead.:DeprecationWarning:utcnow",
+    "ignore:Using the 'utcnow[.](as_date|to_datetime|to_date|get_datetime|get_date|date|datetime)[(][)]' function alias is deprecated. Use the 'utcnow[.]as_datetime[(][)]' function instead.:DeprecationWarning:utcnow",
+]
+
 [tool.coverage.run]
 omit = ["tests/*"]

--- a/tests/test_datetime_compare.py
+++ b/tests/test_datetime_compare.py
@@ -66,50 +66,62 @@ def test_sorted_timestamp_list() -> None:
     assert list_alphabetical_order_reversed != values
     assert list_alphabetical_order != list_alphabetical_order_reversed
 
-    list_datetime_order = sorted(values, key=utcnow.datetime)
-    list_rfc3799_timestamp_order = sorted(values, key=utcnow.str)
+    list_datetime_order = sorted(values, key=utcnow.as_datetime)
+    list_rfc3799_timestamp_order = sorted(values, key=utcnow.rfc3339_timestamp)
 
     assert list_datetime_order == list_rfc3799_timestamp_order
 
-    assert sorted(list_alphabetical_order_reversed, key=utcnow.datetime) != list_datetime_order
-    assert sorted(list_alphabetical_order_reversed, key=utcnow.str) != list_rfc3799_timestamp_order
+    assert sorted(list_alphabetical_order_reversed, key=utcnow.as_datetime) != list_datetime_order
+    assert sorted(list_alphabetical_order_reversed, key=utcnow.rfc3339_timestamp) != list_rfc3799_timestamp_order
 
     assert sorted(list_alphabetical_order_reversed) == sorted(list_alphabetical_order)
-    assert sorted(list_alphabetical_order_reversed, key=utcnow.datetime) != sorted(
-        list_alphabetical_order, key=utcnow.datetime
+    assert sorted(list_alphabetical_order_reversed, key=utcnow.as_datetime) != sorted(
+        list_alphabetical_order, key=utcnow.as_datetime
     )
-    assert sorted(list_alphabetical_order_reversed, key=utcnow.str) != sorted(list_alphabetical_order, key=utcnow.str)
+    assert sorted(list_alphabetical_order_reversed, key=utcnow.rfc3339_timestamp) != sorted(
+        list_alphabetical_order, key=utcnow.rfc3339_timestamp
+    )
 
-    assert sorted(sorted(list_alphabetical_order_reversed), key=utcnow.datetime) == sorted(
-        sorted(list_alphabetical_order), key=utcnow.datetime
+    assert sorted(sorted(list_alphabetical_order_reversed), key=utcnow.as_datetime) == sorted(
+        sorted(list_alphabetical_order), key=utcnow.as_datetime
     )
-    assert sorted(sorted(list_alphabetical_order_reversed), key=utcnow.str) == sorted(
-        sorted(list_alphabetical_order), key=utcnow.str
+    assert sorted(sorted(list_alphabetical_order_reversed), key=utcnow.rfc3339_timestamp) == sorted(
+        sorted(list_alphabetical_order), key=utcnow.rfc3339_timestamp
     )
 
     list_output_datetimes_reordered = list(
-        map(utcnow.datetime, sorted(list_alphabetical_order_reversed, key=utcnow.datetime))
+        map(utcnow.as_datetime, sorted(list_alphabetical_order_reversed, key=utcnow.as_datetime))
     )
-    list_output_datetimes_ordered = list(map(utcnow.datetime, sorted(list_alphabetical_order, key=utcnow.datetime)))
-    list_output_strings_reordered = list(map(utcnow.str, sorted(list_alphabetical_order_reversed, key=utcnow.str)))
-    list_output_strings_ordered = list(map(utcnow.str, sorted(list_alphabetical_order, key=utcnow.str)))
+    list_output_datetimes_ordered = list(
+        map(utcnow.as_datetime, sorted(list_alphabetical_order, key=utcnow.as_datetime))
+    )
+    list_output_strings_reordered = list(
+        map(utcnow.rfc3339_timestamp, sorted(list_alphabetical_order_reversed, key=utcnow.rfc3339_timestamp))
+    )
+    list_output_strings_ordered = list(
+        map(utcnow.rfc3339_timestamp, sorted(list_alphabetical_order, key=utcnow.rfc3339_timestamp))
+    )
 
     assert list_output_datetimes_reordered == list_output_datetimes_ordered
     assert list_output_strings_reordered == list_output_strings_ordered
 
-    assert sorted(map(utcnow.datetime, values)) == list_output_datetimes_reordered == list_output_datetimes_ordered
-    assert sorted(map(utcnow.str, values)) == list_output_strings_reordered == list_output_strings_reordered
+    assert sorted(map(utcnow.as_datetime, values)) == list_output_datetimes_reordered == list_output_datetimes_ordered
+    assert (
+        sorted(map(utcnow.rfc3339_timestamp, values)) == list_output_strings_reordered == list_output_strings_reordered
+    )
 
-    expected_list = sorted(map(utcnow.str, values))
+    expected_list = sorted(map(utcnow.rfc3339_timestamp, values))
 
     for _ in range(0, 20):
         shuffled_values = values[:]
         random.shuffle(shuffled_values)
 
-        assert sorted(map(utcnow.str, shuffled_values)) == expected_list
-        assert sorted(map(utcnow.datetime, shuffled_values)) == list(map(utcnow.datetime, expected_list))
+        assert sorted(map(utcnow.rfc3339_timestamp, shuffled_values)) == expected_list
+        assert sorted(map(utcnow.as_datetime, shuffled_values)) == list(map(utcnow.as_datetime, expected_list))
         assert sorted(map(utcnow.unixtime, shuffled_values)) == list(map(utcnow.unixtime, expected_list))
 
-        assert list(map(utcnow.str, sorted(shuffled_values, key=utcnow.str))) == expected_list
-        assert list(map(utcnow.str, sorted(shuffled_values, key=utcnow.datetime))) == expected_list
-        assert list(map(utcnow.str, sorted(shuffled_values, key=utcnow.unixtime))) == expected_list
+        assert (
+            list(map(utcnow.rfc3339_timestamp, sorted(shuffled_values, key=utcnow.rfc3339_timestamp))) == expected_list
+        )
+        assert list(map(utcnow.rfc3339_timestamp, sorted(shuffled_values, key=utcnow.as_datetime))) == expected_list
+        assert list(map(utcnow.rfc3339_timestamp, sorted(shuffled_values, key=utcnow.unixtime))) == expected_list

--- a/tests/test_modifier.py
+++ b/tests/test_modifier.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 from freezegun import freeze_time
 
@@ -25,9 +25,9 @@ def test_unixtime_modifier() -> None:
 
 
 def test_datetime_modifier() -> None:
-    assert utcnow.as_datetime(0, "+7d") == datetime(1970, 1, 8, 0, 0, 0, 0, tzinfo=UTC)
+    assert utcnow.as_datetime(0, "+7d") == datetime(1970, 1, 8, 0, 0, 0, 0, tzinfo=timezone.utc)
     assert utcnow.as_datetime("2022-10-17T15:15:22.556084Z", "+365d") == datetime(
-        2023, 10, 17, 15, 15, 22, 556084, tzinfo=UTC
+        2023, 10, 17, 15, 15, 22, 556084, tzinfo=timezone.utc
     )
     assert utcnow.as_datetime("now", "+60s") > utcnow.as_datetime("now")
     assert utcnow.as_datetime("+60s") > utcnow.as_datetime("now")

--- a/tests/test_modifier.py
+++ b/tests/test_modifier.py
@@ -1,15 +1,19 @@
+from datetime import UTC, datetime
+
 from freezegun import freeze_time
 
 import utcnow
 
 
 def test_rfc3339_modifier() -> None:
+    assert utcnow.rfc3339_timestamp(0, "+7d") == "1970-01-08T00:00:00.000000Z"
     assert utcnow.rfc3339_timestamp("2022-10-17T15:15:22.556084Z", "+365d") == "2023-10-17T15:15:22.556084Z"
     assert utcnow.rfc3339_timestamp("2022-10-17T15:15:22.556084Z", ".4") == "2022-10-17T15:15:22.956084Z"
     assert utcnow.rfc3339_timestamp(1666019834.321119, "-10s") == "2022-10-17T15:17:04.321119Z"
 
 
 def test_unixtime_modifier() -> None:
+    assert utcnow.unixtime(0, "+7d") == 604800.0
     assert utcnow.unixtime(0, "+10s") == 10.0
     assert utcnow.unixtime(0, "+24h") == 86400.0
     assert utcnow.unixtime("now", None) < utcnow.unixtime("+1s")
@@ -21,6 +25,7 @@ def test_unixtime_modifier() -> None:
 
 
 def test_datetime_modifier() -> None:
+    assert utcnow.as_datetime(0, "+7d") == datetime(1970, 1, 8, 0, 0, 0, 0, tzinfo=UTC)
     assert utcnow.as_datetime("now", "+60s") > utcnow.as_datetime("now")
     assert utcnow.as_datetime("+60s") > utcnow.as_datetime("now")
     assert utcnow.as_datetime("-60s") < utcnow.as_datetime("now")

--- a/tests/test_modifier.py
+++ b/tests/test_modifier.py
@@ -26,6 +26,9 @@ def test_unixtime_modifier() -> None:
 
 def test_datetime_modifier() -> None:
     assert utcnow.as_datetime(0, "+7d") == datetime(1970, 1, 8, 0, 0, 0, 0, tzinfo=UTC)
+    assert utcnow.as_datetime("2022-10-17T15:15:22.556084Z", "+365d") == datetime(
+        2023, 10, 17, 15, 15, 22, 556084, tzinfo=UTC
+    )
     assert utcnow.as_datetime("now", "+60s") > utcnow.as_datetime("now")
     assert utcnow.as_datetime("+60s") > utcnow.as_datetime("now")
     assert utcnow.as_datetime("-60s") < utcnow.as_datetime("now")

--- a/tests/test_module_calls.py
+++ b/tests/test_module_calls.py
@@ -6,13 +6,14 @@ def test_module() -> None:
     import utcnow
 
     # Test types
-    assert isinstance(utcnow, ModuleType)  # type: ignore
+    assert isinstance(utcnow, ModuleType)
     assert utcnow.__class__ is ModuleType
     assert len(str(utcnow)) == 27
     assert isinstance(repr(utcnow), str)
     assert len(repr(utcnow)) == 27
 
-    # Modules aren't callable, but this one is – it's frowned upon and bad practice.
+    # Modules aren't supposed to be callable, but this one is – it's frowned upon and bad practice.
+    # In this case, it's a feature, although experimental.
     assert utcnow("1984-08-01") == "1984-08-01T00:00:00.000000Z"
     assert utcnow("1984-08-01 00:00:00") == "1984-08-01T00:00:00.000000Z"
     assert utcnow("1984-08-01 12:00:00") != "1984-08-01T00:00:00.000000Z"

--- a/tests/test_module_calls.py
+++ b/tests/test_module_calls.py
@@ -14,12 +14,12 @@ def test_module() -> None:
 
     # Modules aren't supposed to be callable, but this one is – it's frowned upon and bad practice.
     # In this case, it's a feature, although experimental.
-    assert utcnow("1984-08-01") == "1984-08-01T00:00:00.000000Z"
-    assert utcnow("1984-08-01 00:00:00") == "1984-08-01T00:00:00.000000Z"
-    assert utcnow("1984-08-01 12:00:00") != "1984-08-01T00:00:00.000000Z"
-    assert datetime.datetime.strptime(utcnow(), "%Y-%m-%dT%H:%M:%S.%f%z")
+    assert utcnow("1984-08-01") == "1984-08-01T00:00:00.000000Z"  # type: ignore
+    assert utcnow("1984-08-01 00:00:00") == "1984-08-01T00:00:00.000000Z"  # type: ignore
+    assert utcnow("1984-08-01 12:00:00") != "1984-08-01T00:00:00.000000Z"  # type: ignore
+    assert datetime.datetime.strptime(utcnow(), "%Y-%m-%dT%H:%M:%S.%f%z")  # type: ignore
     assert datetime.datetime.strptime(str(utcnow), "%Y-%m-%dT%H:%M:%S.%f%z")
-    assert utcnow(datetime.datetime(2021, 4, 30, 8, 0)) == "2021-04-30T08:00:00.000000Z"
+    assert utcnow(datetime.datetime(2021, 4, 30, 8, 0)) == "2021-04-30T08:00:00.000000Z"  # type: ignore
 
     # Testing module functions
     assert utcnow.utcnow("1984-08-01") == "1984-08-01T00:00:00.000000Z"
@@ -36,7 +36,6 @@ def test_module() -> None:
     assert utcnow.get_rfc3339("1984-08-01") == "1984-08-01T00:00:00.000000Z"
     assert utcnow.get("1984-08-01") == "1984-08-01T00:00:00.000000Z"
     assert utcnow.string("1984-08-01") == "1984-08-01T00:00:00.000000Z"
-    assert utcnow.str("1984-08-01") == "1984-08-01T00:00:00.000000Z"
     assert utcnow.rfc3339("1984-08-01") == "1984-08-01T00:00:00.000000Z"
     assert utcnow.utcnow("1984-08-01") == "1984-08-01T00:00:00.000000Z"
     assert utcnow.utcnow.as_string("1984-08-01") == "1984-08-01T00:00:00.000000Z"
@@ -47,7 +46,6 @@ def test_module() -> None:
     assert datetime.datetime.strptime(utcnow.as_string(), "%Y-%m-%dT%H:%M:%S.%f%z")
     assert datetime.datetime.strptime(utcnow.as_str(), "%Y-%m-%dT%H:%M:%S.%f%z")
     assert datetime.datetime.strptime(utcnow.string(), "%Y-%m-%dT%H:%M:%S.%f%z")
-    assert datetime.datetime.strptime(utcnow.str(), "%Y-%m-%dT%H:%M:%S.%f%z")
     assert datetime.datetime.strptime(utcnow.utcnow.as_string(), "%Y-%m-%dT%H:%M:%S.%f%z")
     assert datetime.datetime.strptime(utcnow.utcnow.as_str(), "%Y-%m-%dT%H:%M:%S.%f%z")
     assert datetime.datetime.strptime(utcnow.utcnow.string(), "%Y-%m-%dT%H:%M:%S.%f%z")
@@ -70,9 +68,6 @@ def test_module() -> None:
         2021, 4, 30, 8, 0, 10, tzinfo=datetime.timezone.utc
     )
     assert utcnow.get_date("2021-04-30T08:00:10.000000Z") == datetime.datetime(
-        2021, 4, 30, 8, 0, 10, tzinfo=datetime.timezone.utc
-    )
-    assert utcnow.datetime("2021-04-30T08:00:10.000000Z") == datetime.datetime(
         2021, 4, 30, 8, 0, 10, tzinfo=datetime.timezone.utc
     )
     assert utcnow.date("2021-04-30T08:00:10.000000Z") == datetime.datetime(
@@ -149,8 +144,9 @@ def test_module() -> None:
     )
 
     # Testing function imports
-    from utcnow import as_date_string, as_str, as_string
-    from utcnow import str as str_
+    from utcnow import as_date_string, as_str
+    from utcnow import as_string
+    from utcnow import as_string as str_
     from utcnow import string
 
     assert as_string("1984-08-01") == "1984-08-01T00:00:00.000000Z"

--- a/tests/test_module_calls.py
+++ b/tests/test_module_calls.py
@@ -1,11 +1,13 @@
 import datetime
+from types import ModuleType
 
 
 def test_module() -> None:
     import utcnow
 
     # Test types
-    assert type(utcnow) is utcnow._module  # type: ignore
+    assert isinstance(utcnow, ModuleType)  # type: ignore
+    assert utcnow.__class__ is ModuleType
     assert len(str(utcnow)) == 27
     assert isinstance(repr(utcnow), str)
     assert len(repr(utcnow)) == 27

--- a/tests/test_now.py
+++ b/tests/test_now.py
@@ -144,12 +144,13 @@ def test_utcnow_now_functionality() -> None:
     assert len(repr(now)) == 27
     assert len(now()) == 27
 
-    a = utcnow.now()
-    b = utcnow.now()
-    c = utcnow.now()
-    d = utcnow.now()
-    e = utcnow.now()
-    f = utcnow.now()
+    a: str = utcnow.now()
+    b: str = utcnow.now()
+    c: str = utcnow.now()
+    d: str = utcnow.now()
+    e: str = utcnow.now()
+    f: str = utcnow.now()
+
     assert a <= b <= c <= d <= e <= f
 
     a = str(utcnow.now)

--- a/tests/test_now.py
+++ b/tests/test_now.py
@@ -110,7 +110,8 @@ def test_now_list_datetime() -> None:
 
 def test_utcnow_now_functionality() -> None:
     import utcnow
-    from utcnow import now, utcnow_
+    from utcnow import now
+    from utcnow import utcnow as utcnow_
 
     assert type(utcnow.now) is not str  # type: ignore
     assert not isinstance(utcnow.now, str)

--- a/tests/test_synchronizer.py
+++ b/tests/test_synchronizer.py
@@ -44,10 +44,9 @@ def test_synchronizer_timediff() -> None:
 
 
 def test_synchronizer_now() -> None:
-    with utcnow.synchronizer:
+    with utcnow.synchronizer("now"):
         created_time = utcnow.rfc3339_timestamp()
         expire_time = utcnow.rfc3339_timestamp("now", "+15m")
-
     assert utcnow.timediff(created_time, expire_time, "seconds") == 900.0
 
 

--- a/tests/test_synchronizer.py
+++ b/tests/test_synchronizer.py
@@ -1,0 +1,206 @@
+from typing import Any, cast
+
+import pytest
+
+import utcnow
+
+
+def test_synchronizer_basic() -> None:
+    with utcnow.synchronizer as synchronizer:
+        assert utcnow.rfc3339_timestamp() == utcnow.rfc3339_timestamp("now")
+        assert utcnow.as_unixtime() == utcnow.as_unixtime("now")
+        assert utcnow.as_protobuf() == utcnow.as_protobuf("now")
+        assert utcnow.as_datetime() == utcnow.as_datetime("now")
+
+        assert synchronizer.datetime == utcnow.as_datetime()
+        assert synchronizer.time == utcnow.as_unixtime()
+        assert synchronizer.time_ns == int(utcnow.as_unixtime() * 1e6) * 1_000
+
+    with utcnow.utcnow.synchronizer as synchronizer:
+        assert utcnow.rfc3339_timestamp() == utcnow.rfc3339_timestamp("now")
+        assert utcnow.as_unixtime() == utcnow.as_unixtime("now")
+        assert utcnow.as_protobuf() == utcnow.as_protobuf("now")
+        assert utcnow.as_datetime() == utcnow.as_datetime("now")
+
+        assert synchronizer.datetime == utcnow.as_datetime()
+        assert synchronizer.time == utcnow.as_unixtime()
+        assert synchronizer.time_ns == int(utcnow.as_unixtime() * 1e6) * 1_000
+
+
+def test_synchronizer_timediff() -> None:
+    assert utcnow.timediff("now", "now") == 0.0
+    assert utcnow.timediff("now", "+1h") == 3600.0
+    assert utcnow.timediff("-1h", "+0.5h") == 5400.0
+
+    with utcnow.synchronizer:
+        assert utcnow.timediff("now", "now") == 0.0
+        assert utcnow.timediff("now", "+1h") == 3600.0
+        assert utcnow.timediff("-1h", "+0.5h") == 5400.0
+
+    with utcnow.synchronizer("1984-08-01 20:50:33.414100+02:00"):
+        assert utcnow.timediff("now", "now") == 0.0
+        assert utcnow.timediff("now", "+1h") == 3600.0
+        assert utcnow.timediff("-1h", "+0.5h") == 5400.0
+
+
+def test_synchronizer_now() -> None:
+    with utcnow.synchronizer:
+        created_time = utcnow.rfc3339_timestamp()
+        expire_time = utcnow.rfc3339_timestamp("now", "+15m")
+
+    assert utcnow.timediff(created_time, expire_time, "seconds") == 900.0
+
+
+def test_synchronizer_specific() -> None:
+    with utcnow.synchronizer("2022-01-01T01:00:00.000000Z") as synchronizer:
+        created_time = utcnow.rfc3339_timestamp()
+        expire_time = utcnow.rfc3339_timestamp("now", "+15m")
+
+        assert synchronizer.datetime == utcnow.as_datetime()
+        assert synchronizer.time == utcnow.as_unixtime()
+        assert synchronizer.time_ns == int(utcnow.as_unixtime() * 1e6) * 1_000
+
+    assert utcnow.timediff(created_time, expire_time, "seconds") == 900.0
+    assert created_time == "2022-01-01T01:00:00.000000Z"
+    assert expire_time == "2022-01-01T01:15:00.000000Z"
+
+
+def test_synchronizer_precise_unixtime() -> None:
+    with utcnow.synchronizer(1695694079.9417229) as synchronizer:
+        created_time = utcnow.rfc3339_timestamp()
+        expire_time = utcnow.rfc3339_timestamp("now", "+15m")
+
+        assert synchronizer.datetime == utcnow.as_datetime()
+        assert synchronizer.time == utcnow.as_unixtime()
+        assert synchronizer.time_ns == int(utcnow.as_unixtime() * 1e6) * 1_000
+
+        assert synchronizer.time == 1695694079.941723
+        assert synchronizer.time_ns == 1695694079941723000
+
+    assert utcnow.timediff(created_time, expire_time, "seconds") == 900.0
+    assert created_time == "2023-09-26T02:07:59.941723Z"
+    assert expire_time == "2023-09-26T02:22:59.941723Z"
+
+
+def test_synchronizer_approximate_unixtime() -> None:
+    with utcnow.synchronizer(1695694079.941723) as synchronizer:
+        created_time = utcnow.rfc3339_timestamp()
+        expire_time = utcnow.rfc3339_timestamp("now", "+15m")
+
+        assert synchronizer.datetime == utcnow.as_datetime()
+        assert synchronizer.time == utcnow.as_unixtime()
+        assert synchronizer.time_ns == int(utcnow.as_unixtime() * 1e6) * 1_000
+
+        assert synchronizer.time == 1695694079.941723
+        assert synchronizer.time_ns == 1695694079941723000
+
+    assert utcnow.timediff(created_time, expire_time, "seconds") == 900.0
+    assert created_time == "2023-09-26T02:07:59.941723Z"
+    assert expire_time == "2023-09-26T02:22:59.941723Z"
+
+
+def test_synchronizer_only_modifier() -> None:
+    now = utcnow.rfc3339_timestamp()
+
+    with utcnow.synchronizer(utcnow.NOW, "+1h"):
+        timestamp = utcnow.rfc3339_timestamp()
+
+    assert 3601.0 > utcnow.timediff(now, timestamp, "seconds") >= 3600.0
+
+    with utcnow.synchronizer("-10s"):
+        timestamp = utcnow.rfc3339_timestamp()
+
+    assert -10.0 < utcnow.timediff(now, timestamp, "seconds") < -9.0
+
+
+def test_synchronizer_expired() -> None:
+    synchronizer1 = utcnow.synchronizer("2022-01-01T01:00:00.000000Z")
+    synchronizer2 = utcnow.synchronizer("2022-01-01T02:00:00.000000Z")
+    assert synchronizer1 is not synchronizer2
+
+    assert "expired" in repr(synchronizer1)
+    assert "pending context" in repr(synchronizer2)
+
+    with pytest.raises(RuntimeError):
+        with synchronizer1 as synchronizer:
+            pass
+
+    assert utcnow.rfc3339_timestamp() != "2022-01-01T02:00:00.000000Z"
+
+    with synchronizer2 as synchronizer:
+        assert utcnow.rfc3339_timestamp() == "2022-01-01T02:00:00.000000Z"
+        assert synchronizer is utcnow.synchronizer
+
+    assert utcnow.rfc3339_timestamp() != "2022-01-01T02:00:00.000000Z"
+
+    with pytest.raises(RuntimeError):
+        with synchronizer2 as synchronizer:
+            pass
+
+
+def test_synchronizer_reuse() -> None:
+    synchronizer = cast(Any, utcnow.synchronizer("2022-01-01T01:00:00.000000Z"))
+
+    with pytest.raises(RuntimeError):
+        synchronizer("2022-01-01T01:00:00.000000Z")
+
+
+def test_synchronizer_repr() -> None:
+    synchronizer1 = utcnow.synchronizer()
+
+    assert "pending context" in repr(synchronizer1)
+    assert "pending context" not in repr(utcnow.synchronizer)
+
+    with synchronizer1 as synchronizer:
+        assert synchronizer is utcnow.synchronizer
+        assert synchronizer == utcnow.synchronizer
+        assert synchronizer is not synchronizer1
+        assert synchronizer != synchronizer1
+        assert "child" in repr(synchronizer1)
+        assert "active context" in repr(synchronizer1)
+        assert "main" in repr(synchronizer)
+        assert "active context" in repr(synchronizer)
+
+    assert "active context" not in repr(synchronizer1)
+    assert "active context" not in repr(synchronizer)
+    assert "deactivated context" in repr(synchronizer1)
+
+    with pytest.raises(RuntimeError):
+        with synchronizer1:
+            pass
+
+
+def test_synchronizer_orphan() -> None:
+    synchronizer1 = utcnow.synchronizer("+10h")
+
+    assert "pending context" in repr(synchronizer1)
+    assert "pending context" not in repr(utcnow.synchronizer)
+
+    with utcnow.synchronizer as synchronizer:
+        assert synchronizer is utcnow.synchronizer
+        assert synchronizer is not synchronizer1
+        assert "child" in repr(synchronizer1)
+        assert "expired" in repr(synchronizer1)
+        assert "main" in repr(synchronizer)
+        assert "active context" in repr(synchronizer)
+
+    assert "expired" in repr(synchronizer1)
+
+    with pytest.raises(RuntimeError):
+        with synchronizer1:
+            pass
+
+
+def test_synchronizer_nested() -> None:
+    with utcnow.synchronizer("2022-01-01T01:00:00.000000Z"):
+        with pytest.raises(RuntimeError):
+            with utcnow.synchronizer:
+                pass
+
+    with utcnow.synchronizer:
+        with pytest.raises(RuntimeError):
+            with utcnow.synchronizer:
+                pass
+
+        with pytest.raises(RuntimeError):
+            utcnow.synchronizer()

--- a/tests/test_timediff.py
+++ b/tests/test_timediff.py
@@ -85,6 +85,16 @@ def test_timediff_birth() -> None:
     assert utcnow.timediff(begin, end) == utcnow.timediff(begin, utcnow.unixtime(end))
 
 
+def test_timediff_frozen_now() -> None:
+    import utcnow
+
+    assert utcnow.timediff("now", "now") == 0
+    assert utcnow.timediff("now", "+1h") == 3600.0
+    assert utcnow.timediff("+2h", "+3600s") == -3600.0
+    assert utcnow.timediff("now", "+1us") == 0.000001
+    assert utcnow.timediff("-50us", "+3.049ms", "us") == 3099.0
+
+
 def test_timediff_invalid_unit() -> None:
     import utcnow
 

--- a/tests/test_timediff.py
+++ b/tests/test_timediff.py
@@ -12,6 +12,10 @@ def test_timediff_basic() -> None:
     assert utcnow.timediff(end=1, begin=0) == 1
     assert utcnow.timediff(0, 2) == 2
     assert utcnow.timediff(0, 60) == 60
+    assert utcnow.timediff(0, 4.711, "milliseconds") == 4711.0
+    assert utcnow.timediff(0, 0.013338, "microseconds") == 13338.0
+    assert utcnow.timediff(0, 0.000042, "nanoseconds") == 42000.0
+    assert utcnow.timediff(0, 60, "seconds") == 60
     assert utcnow.timediff(0, 60, "minutes") == 1
     assert utcnow.timediff(0, 60 * 60, "minutes") == 60
     assert utcnow.timediff(0, 60 * 60, "hours") == 1
@@ -44,6 +48,8 @@ def test_timediff_comparison() -> None:
     assert round(utcnow.timediff("1984-08-01T00:50:15", "1984-08-02", "days"), 8) == round(0.96510417, 8)
 
     assert utcnow.timediff("1984-08-01T13:38:00.471100Z", "1984-08-01T13:38:00.471101Z") == 0.000001
+    assert utcnow.timediff("1984-08-01T13:38:00.471100Z", "1984-08-01T13:38:00.471101Z", "ms") == 0.001
+    assert utcnow.timediff("1984-08-01T13:38:00.471100Z", "1984-08-01T13:38:00.471101Z", "us") == 1.0
     assert utcnow.timediff("1984-08-01T13:38:00.471100Z", "1984-08-01T13:38:01") == 0.528900
     assert utcnow.timediff("1984-08-01T13:38:00.471100Z", "1984-08-01T13:38:01.000000Z") == 0.528900
     assert utcnow.timediff("1984-08-01T13:38:00.471100Z", "1984-08-01T13:38:01.000000+00:00") == 0.528900

--- a/tests/test_timediff.py
+++ b/tests/test_timediff.py
@@ -72,8 +72,8 @@ def test_timediff_birth() -> None:
     end = "2021-02-27T08:54:30.999999Z"
 
     assert utcnow.timediff(begin, end) == utcnow.timediff(utcnow.get(begin), utcnow.get(end))
-    assert utcnow.timediff(begin, end) == utcnow.timediff(utcnow.datetime(begin), utcnow.datetime(end))
-    assert utcnow.timediff(begin, end) == utcnow.timediff(utcnow.datetime(begin), utcnow.get(end))
+    assert utcnow.timediff(begin, end) == utcnow.timediff(utcnow.as_datetime(begin), utcnow.as_datetime(end))
+    assert utcnow.timediff(begin, end) == utcnow.timediff(utcnow.as_datetime(begin), utcnow.get(end))
     assert utcnow.timediff(begin, end) == utcnow.timediff(utcnow.unixtime(begin), utcnow.get(end))
     assert utcnow.timediff(begin, end) == utcnow.timediff(utcnow.unixtime(begin), utcnow.unixtime(end))
     assert utcnow.timediff(begin, end) == utcnow.timediff(begin, utcnow.unixtime(end))

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -1,3 +1,55 @@
+"""
+Timestamps as RFC 3339 (Date & Time on the Internet) formatted strings with conversion functionality from other
+timestamp formats or for timestamps on other timezones. Additionally converts timestamps from datetime objets
+and other common date utilities.
+
+``utcnow.rfc3339_timestamp(value, modifier)``
+    Transforms the input value to a timestamp string in RFC3339 format.
+``utcnow.as_datetime(value, modifier)``
+    Transforms the input value to a datetime object.
+``utcnow.as_unixtime(value, modifier)``
+    Transforms the input value to a float value representing unixtime.
+``utcnow.as_protobuf(value, modifier)``
+    Transforms the input value to a google.protobuf.Timestamp message.
+
+value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+    Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+    Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+Examples:
+
+    A few examples of transforming an arbitrary timestamp value to a RFC3339 timestamp string.
+
+    >>> import utcnow
+    >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00")
+    "2023-09-07T02:18:00.000000Z"
+    >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00", "+7d")
+    "2023-09-14T02:18:00.000000Z"
+    >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00+02:00")
+    "2023-09-07T00:18:00.000000Z"
+    >>> utcnow.rfc3339_timestamp(1693005993.285967)
+    "2023-08-25T23:26:33.285967Z"
+    >>> utcnow.rfc3339_timestamp()
+    "2023-09-07T01:04:38.091041Z"  # current time
+
+Returned timestamps follow RFC 3339 (Date and Time on the Internet: Timestamps): https://tools.ietf.org/html/rfc3339.
+
+Timestamps are converted to UTC timezone which we'll note in the timestamp with the "Z" syntax instead of the also
+accepted "+00:00". "Z" stands for UTC+0 or "Zulu time" and refers to the zone description of zero hours.
+
+Timestamps are expressed as a date-time (not a Python datetime object), including the full date (the "T" between the
+date and the time is optional in RFC 3339 (but not in ISO 8601) and usually describes the beginning of the time part.
+
+Timestamps are 27 characters long in the format: "YYYY-MM-DDTHH:mm:ss.ffffffZ". 4 digit year, 2 digit month, 2 digit
+days, "T", 2 digit hours, 2 digit minutes, 2 digit seconds, 6 fractional second digits (microseconds -> nanoseconds),
+followed by the timezone identifier for UTC: "Z".
+
+The library is specified to return timestamps with 6 fractional second digits, which means timestamps down to the
+microsecond level. Having a six-digit fraction of a second is currently the most common way that timestamps are shown
+at this date.
+"""
+
 from __future__ import annotations
 
 import functools
@@ -19,14 +71,6 @@ str_ = str
 
 __author__: str_ = "Carl Oscar Aaro"
 __email__: str_ = "hello@carloscar.com"
-
-"""
-* Timestamps follow RFC 3339 (Date and Time on the Internet: Timestamps): https://tools.ietf.org/html/rfc3339.
-* Timestamps are converted to UTC timezone which we'll note in the timestamp with the "Z" syntax instead of the also accepted "+00:00". "Z" stands for UTC+0 or "Zulu time" and refers to the zone description of zero hours.
-* Timestamps are expressed as a date-time, including the full date (the "T" between the date and the time is optional in RFC 3339 (but not in ISO 8601) and usually describes the beginning of the time part.
-* Timestamps are 27 characters long in the format: "YYYY-MM-DDTHH:mm:ss.ffffffZ". 4 digit year, 2 digit month, 2 digit days. "T", 2 digit hours, 2 digit minutes, 2 digit seconds, 6 fractional second digits (microseconds -> nanoseconds), followed by the timezone identifier for UTC: "Z".
-* The library is specified to return timestamps with 6 fractional second digits, which means timestamps down to the microsecond level. Having a six-digit fraction of a second is currently the most common way that timestamps are shown at this date.
-"""
 
 _SENTINEL = object()
 
@@ -523,7 +567,7 @@ class utcnow_(_baseclass):
         """Transforms the input value to a google.protobuf.Timestamp protobuf message.
 
         Args:
-            value: A value representing a timestamp in any of the allowed input formats.
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
             modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
                 Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
                 Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -58,1093 +58,810 @@ See also:
 
 from __future__ import annotations
 
-import functools
-import re
 import sys
-import time as time_
-from datetime import datetime as datetime_
-from datetime import timedelta as timedelta_
-from datetime import timezone as timezone_
-from datetime import tzinfo as tzinfo_
-from decimal import Decimal
-from numbers import Real
-from types import FunctionType, ModuleType
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union, cast
 
-from .__version_data__ import __version__, __version_info__
-from .protobuf import TimestampProtobufMessage
+if not getattr(sys.modules[__name__], "__original_module__", None):
+    import functools
+    import re
+    import sys
+    import time as time_
+    from datetime import datetime as datetime_
+    from datetime import timedelta as timedelta_
+    from datetime import timezone as timezone_
+    from datetime import tzinfo as tzinfo_
+    from decimal import Decimal
+    from numbers import Real
+    from types import FunctionType, ModuleType
+    from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union, cast
 
-str_ = str
+    from .__version_data__ import __version__, __version_info__
+    from .protobuf import TimestampProtobufMessage
 
-__author__: str_ = "Carl Oscar Aaro"
-__email__: str_ = "hello@carloscar.com"
+    str_ = str
 
-_SENTINEL = object()
+    __author__: str_ = "Carl Oscar Aaro"
+    __email__: str_ = "hello@carloscar.com"
 
-# the following formats are accepted as date and date+time as string formatted input values.
-# the library also accepts numeric values (int / float), specified as unixtime, or datetime objects.
-# if no timezone is specified in input, utc is assumed.
-_ACCEPTED_INPUT_FORMAT_VALUES = (
-    "%Y-%m-%dT%H:%M:%S.%f%z",
-    "%Y-%m-%d %H:%M:%S.%f%z",
-    "%Y-%m-%dT%H:%M:%S.%f %z",
-    "%Y-%m-%d %H:%M:%S.%f %z",
-    "%Y-%m-%dT%H:%M:%S.%f",
-    "%Y-%m-%d %H:%M:%S.%f",
-    "%Y-%m-%dT%H:%M:%S%z",
-    "%Y-%m-%d %H:%M:%S%z",
-    "%Y-%m-%dT%H:%M:%S %z",
-    "%Y-%m-%d %H:%M:%S %z",
-    "%Y-%m-%dT%H:%M:%S",
-    "%Y-%m-%d %H:%M:%S",
-    "%Y-%m-%dT%H:%M%z",
-    "%Y-%m-%d %H:%M%z",
-    "%Y-%m-%dT%H:%M %z",
-    "%Y-%m-%d %H:%M %z",
-    "%Y-%m-%d%z",
-    "%Y-%m-%dT%H:%M",
-    "%Y-%m-%d %H:%M",
-    "%Y-%m-%d %z",
-    "%Y-%m-%d",
-)
+    _SENTINEL = object()
 
-# examples: "123", "-123", "123.456", "-123.456", "123.", "-123.", ".456", "-.456"
-NUMERIC_REGEX = re.compile(r"^[-]?([0-9]+|[.][0-9]+|[0-9]+[.]|[0-9]+[.][0-9]+)$")
-
-# examples: "2023-09-06T23:53:59.684762Z", "2023-09-06 23:53:59.684762+00:00"
-PREFERRED_FORMAT_REGEX = re.compile(
-    r"^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt ]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9].[0-9]{6}([Zz]|[+-]00:00|)$"
-)
-
-# modifier multipliers: "s" (seconds), "m" (minutes), "h" (hours), "d" (days)
-# example: a modifier value of "+10d" => add 10 days.
-# example: a modifier value of "-1h" => subtract 1 hour.
-MODIFIER_MUL = {
-    "s": 1,
-    "m": 60,
-    "h": 3600,
-    "d": 86400,
-}
-
-# datetime.timezone.utc
-utc = UTC = timezone_.utc
-
-CT = TypeVar("CT", bound=Callable)
-
-
-@functools.lru_cache(maxsize=128, typed=False)
-def _is_numeric(value: str_) -> bool:
-    """
-    Determines if a string represents a numeric value. A numeric values can optionally start with "-" (negative),
-    optionally have a leading "." (decimal point) before any digit or can optionally end with "." (decimal point),
-    meaning there is no decimal fragment present in the number.
-
-    Args:
-        value: A string to check for numeric representation.
-
-    Returns:
-        True if the string represents a numeric value, False otherwise.
-    """
-    if NUMERIC_REGEX.match(value):
-        return True
-
-    return False
-
-
-def _init_modifier(
-    value: Union[str_, datetime_, object, int, float, Decimal, Real, bytes, TimestampProtobufMessage],
-    modifier: Optional[Union[str_, int, float]] = 0,
-) -> Tuple[Union[str_, datetime_, object, int, float, Decimal, Real], Union[int, float]]:
-    """
-    Normalizes the input value + modifier tuple.
-
-    Args:
-        value: A value representing a timestamp in any of the allowed input formats.
-        modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
-            Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
-            Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
-
-    Returns:
-        A tuple containing the normalized value and the modifier.
-    """
-    if isinstance(value, TimestampProtobufMessage):
-        value = value.seconds + round(value.nanos * 1e-9, 9)
-    return _init_modifier_lru(value, modifier)
-
-
-@functools.lru_cache(maxsize=128, typed=True)
-def _init_modifier_lru(
-    value: Union[str_, datetime_, object, int, bytes, float, Decimal, Real],
-    modifier: Optional[Union[str_, int, float]] = 0,
-) -> Tuple[Union[str_, datetime_, object, int, float, Decimal, Real], Union[int, float]]:
-    """
-    Normalizes the input value + modifier tuple.
-
-    Args:
-        value: A value representing a timestamp in any of the allowed input formats.
-        modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
-            Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
-            Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
-
-    Returns:
-        A tuple containing the normalized value and the modifier.
-    """
-    if isinstance(value, bytes):
-        value_ = TimestampProtobufMessage()
-        value_.MergeFromString(value)
-        value = value_.seconds + round(value_.nanos * 1e-9, 9)
-
-    if (
-        value is not _SENTINEL
-        and value
-        and str_(value)[0] in ("+", "-")
-        and not modifier
-        and isinstance(value, str_)
-        and value[-1] in MODIFIER_MUL
-    ):
-        modifier = value
-        value = _SENTINEL
-
-    if modifier is None:
-        modifier = 0
-
-    if isinstance(modifier, str_):
-        modifier_mul: int = 1
-        modifier_mul_str = modifier[-1]
-
-        if len(modifier) > 1 and modifier_mul_str in MODIFIER_MUL and (modifier[-2].isdigit() or modifier[-2] == "."):
-            modifier = modifier[:-1]
-            modifier_mul = MODIFIER_MUL[modifier_mul_str]
-
-        if "." in modifier:
-            modifier = float(modifier) * modifier_mul
-        else:
-            modifier = int(modifier) * modifier_mul
-
-    if value == "now":
-        value = _SENTINEL
-
-    return value, modifier
-
-
-@functools.lru_cache(maxsize=128, typed=True)
-def _transform_value(value: Union[str_, datetime_, object, int, float, Decimal, Real]) -> str_:
-    """Transforms the input value to a timestamp string in RFC3339 format.
-
-    Args:
-        value: A value representing a timestamp in any of the allowed input formats.
-
-    Returns:
-        The transformed value as a string in RFC3339 format.
-    """
-    str_value: str_
-    try:
-        if isinstance(value, str_):
-            str_value = value.strip()
-        elif isinstance(value, (int, float)):
-            return datetime_.fromtimestamp(value, tz=UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
-        elif isinstance(value, (Decimal, Real)):
-            str_value = (
-                datetime_.fromtimestamp(float(value), tz=UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
-            )
-        else:
-            str_value = str_(value).strip()
-
-        if (
-            str_value
-            and len(str_value) <= 21
-            and "T" not in str_value
-            and ":" not in str_value
-            and "/" not in str_value
-            and str_value.count("-") <= 1
-            and _is_numeric(str_value)
-        ):
-            str_value = (
-                datetime_.fromtimestamp(float(str_value), tz=UTC)
-                .isoformat(timespec="microseconds")
-                .replace("+00:00", "Z")
-            )
-    except Exception:
-        raise ValueError(f"The input value '{value}' (type: {value.__class__}) does not match allowed input formats")
-
-    if PREFERRED_FORMAT_REGEX.match(str_value):
-        if int(str_value[8:10]) >= 30 or (int(str_value[5:7]) == 2 and int(str_value[8:10]) >= 28):
-            try:
-                dt_value = datetime_.strptime(str_value[0:10], "%Y-%m-%d")
-            except ValueError:
-                raise ValueError(
-                    f"The input value '{value}' (type: {value.__class__}) does not match allowed input formats"
-                )
-        return (str_value[:10] + "T" + str_value[11:]).upper().rstrip("Z").rsplit("+00:00")[0].rsplit("-00:00")[0] + "Z"
-
-    ends_with_utc = False
-    if str_value.endswith(" UTC"):
-        str_value = str_value[0:-4]
-        ends_with_utc = True
-
-    for format_ in _ACCEPTED_INPUT_FORMAT_VALUES:
-        try:
-            dt_value = datetime_.strptime(str_value, format_)
-        except ValueError:
-            continue
-
-        if ends_with_utc and dt_value.tzinfo:
-            raise ValueError(
-                f"The input value '{value}' (type: {value.__class__}) uses double timezone declaration: 'UTC' and '{dt_value.tzinfo}'"
-            )
-
-        break
-    else:
-        raise ValueError(f"The input value '{value}' (type: {value.__class__}) does not match allowed input formats")
-
-    if not dt_value.tzinfo:
-        # Timezone declaration missing, skipping tz application and blindly assuming UTC
-        return dt_value.isoformat(timespec="microseconds") + "Z"
-
-    return dt_value.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
-
-
-@functools.lru_cache(maxsize=128)
-def _timestamp_to_datetime(value: str_) -> datetime_:
-    """Transforms the input value to a datetime object.
-
-    Args:
-        value: A value representing a timestamp in any of the allowed input formats.
-
-    Returns:
-        The transformed value as a datetime object.
-    """
-    value = _transform_value(value)
-    return datetime_.strptime(value, "%Y-%m-%dT%H:%M:%S.%f%z")
-
-
-@functools.lru_cache(maxsize=128)
-def _timestamp_to_unixtime(value: str_) -> float:
-    """Transforms the input value to a float value representing a timestamp as unixtime.
-
-    Args:
-        value: A value representing a timestamp in any of the allowed input formats.
-
-    Returns:
-        The transformed value in unixtime (float).
-    """
-    return _timestamp_to_datetime(value).timestamp()
-
-
-@functools.lru_cache(maxsize=128)
-def _unixtime_to_protobuf(unixtime_value: Union[int, float]) -> TimestampProtobufMessage:
-    """Transforms the unix timestamp input value to a google.protobuf.Timestamp protobuf message.
-
-    Args:
-        unixtime_value: A timestamp in unixtime format (float).
-
-    Returns:
-        The transformed value as a google.protobuf.Timestamp message.
-    """
-    seconds = int(unixtime_value)
-    nanos = round(int((unixtime_value - seconds) * 1e6)) * 1000
-    if nanos < 0:
-        seconds -= 1
-        nanos += 1_000_000_000
-    return TimestampProtobufMessage(
-        seconds=seconds,
-        nanos=nanos,
+    # the following formats are accepted as date and date+time as string formatted input values.
+    # the library also accepts numeric values (int / float), specified as unixtime, or datetime objects.
+    # if no timezone is specified in input, utc is assumed.
+    _ACCEPTED_INPUT_FORMAT_VALUES = (
+        "%Y-%m-%dT%H:%M:%S.%f%z",
+        "%Y-%m-%d %H:%M:%S.%f%z",
+        "%Y-%m-%dT%H:%M:%S.%f %z",
+        "%Y-%m-%d %H:%M:%S.%f %z",
+        "%Y-%m-%dT%H:%M:%S.%f",
+        "%Y-%m-%d %H:%M:%S.%f",
+        "%Y-%m-%dT%H:%M:%S%z",
+        "%Y-%m-%d %H:%M:%S%z",
+        "%Y-%m-%dT%H:%M:%S %z",
+        "%Y-%m-%d %H:%M:%S %z",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%dT%H:%M%z",
+        "%Y-%m-%d %H:%M%z",
+        "%Y-%m-%dT%H:%M %z",
+        "%Y-%m-%d %H:%M %z",
+        "%Y-%m-%d%z",
+        "%Y-%m-%dT%H:%M",
+        "%Y-%m-%d %H:%M",
+        "%Y-%m-%d %z",
+        "%Y-%m-%d",
     )
 
+    # examples: "123", "-123", "123.456", "-123.456", "123.", "-123.", ".456", "-.456"
+    NUMERIC_REGEX = re.compile(r"^[-]?([0-9]+|[.][0-9]+|[0-9]+[.]|[0-9]+[.][0-9]+)$")
 
-@functools.lru_cache(maxsize=128)
-def _timezone_from_string(value: str_) -> Optional[tzinfo_]:
-    """Converts a string to a timezone object.
+    # examples: "2023-09-06T23:53:59.684762Z", "2023-09-06 23:53:59.684762+00:00"
+    PREFERRED_FORMAT_REGEX = re.compile(
+        r"^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt ]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9].[0-9]{6}([Zz]|[+-]00:00|)$"
+    )
 
-    Args:
-        value: A string representing a 0-offset timezone (UTC) or a timezone string as an offset (for example: +HH:mm).
+    # modifier multipliers: "s" (seconds), "m" (minutes), "h" (hours), "d" (days)
+    # example: a modifier value of "+10d" => add 10 days.
+    # example: a modifier value of "-1h" => subtract 1 hour.
+    MODIFIER_MUL = {
+        "s": 1,
+        "m": 60,
+        "h": 3600,
+        "d": 86400,
+    }
 
-    Returns:
-        A timezone object if the string represents a valid timezone, otherwise None.
-    """
-    if value.upper() in (
-        "UTC",
-        "GMT",
-        "UTC+0",
-        "UTC-0",
-        "GMT+0",
-        "GMT-0",
-        "Z",
-        "ZULU",
-        "00:00",
-        "+00:00",
-        "-00:00",
-        "0000",
-        "+0000",
-        "-0000",
-    ):
-        return UTC
+    # datetime.timezone.utc
+    utc = UTC = timezone_.utc
 
-    if value and value[0] in ("+", "-"):
-        m = re.match(r"^[+-]([0-9]{2}):?([0-9]{2})$", value)
-        if not m:
-            return None
+    CT = TypeVar("CT", bound=Callable)
 
-        modifier = 1 if value[0] == "+" else -1
-
-        td = timedelta_(hours=int(m.group(1)), minutes=int(m.group(2)))
-        if td.days == 1 and td == timedelta_(days=1):
-            td = timedelta_(days=1, microseconds=-1)
-
-        return timezone_(modifier * td)
-
-    return None
-
-
-class _metaclass(type):
-    def __new__(cls: Type[_metaclass], name: str_, bases: Tuple[type, ...], attributedict: Dict) -> _metaclass:
-        result = cast(Type["_baseclass"], super().__new__(cls, name, bases, dict(attributedict)))
-
-        return result
-
-
-class _baseclass(metaclass=_metaclass):
-    def __init__(self) -> None:
-        pass
-
-    def __call__(
-        self,
-        value: Union[str_, datetime_, object, int, float, Decimal, Real] = _SENTINEL,
-        modifier: Optional[Union[str_, int, float]] = 0,
-    ) -> str_:
-        """Transforms the input value to a timestamp string in RFC3339 format.
+    @functools.lru_cache(maxsize=128, typed=False)
+    def _is_numeric(value: str) -> bool:
+        """
+        Determines if a string represents a numeric value. A numeric values can optionally start with "-" (negative),
+        optionally have a leading "." (decimal point) before any digit or can optionally end with "." (decimal point),
+        meaning there is no decimal fragment present in the number.
 
         Args:
-            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            value: A string to check for numeric representation.
+
+        Returns:
+            True if the string represents a numeric value, False otherwise.
+        """
+        if NUMERIC_REGEX.match(value):
+            return True
+
+        return False
+
+    def _init_modifier(
+        value: Union[str, datetime_, object, int, float, Decimal, Real, bytes, TimestampProtobufMessage],
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> Tuple[Union[str, datetime_, object, int, float, Decimal, Real], Union[int, float]]:
+        """
+        Normalizes the input value + modifier tuple.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats.
             modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
                 Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
                 Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
 
         Returns:
-            The transformed value as a string in RFC3339 format.
-
-        Raises:
-            ValueError: If the input value does not match allowed input formats.
+            A tuple containing the normalized value and the modifier.
         """
-        value, modifier = _init_modifier(value, modifier)
+        if isinstance(value, TimestampProtobufMessage):
+            value = value.seconds + round(value.nanos * 1e-9, 9)
+        return _init_modifier_lru(value, modifier)
 
-        if value is _SENTINEL:
-            return (
-                (datetime_.now(UTC) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier))
-                .isoformat(timespec="microseconds")
-                .replace("+00:00", "Z")
-            )
-        return _transform_value(value) if not modifier else _transform_value(_timestamp_to_unixtime(value) + modifier)
+    @functools.lru_cache(maxsize=128, typed=True)
+    def _init_modifier_lru(
+        value: Union[str, datetime_, object, int, bytes, float, Decimal, Real],
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> Tuple[Union[str, datetime_, object, int, float, Decimal, Real], Union[int, float]]:
+        """
+        Normalizes the input value + modifier tuple.
 
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats.
+            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
 
-class now_(_baseclass):
-    def __new__(cls, *args: Any) -> now_:
-        result = object.__new__(cls, *args)
-        return result
+        Returns:
+            A tuple containing the normalized value and the modifier.
+        """
+        if isinstance(value, bytes):
+            value_ = TimestampProtobufMessage()
+            value_.MergeFromString(value)
+            value = value_.seconds + round(value_.nanos * 1e-9, 9)
 
-    def __str__(self) -> str_:
-        return datetime_.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+        if (
+            value is not _SENTINEL
+            and value
+            and str_(value)[0] in ("+", "-")
+            and not modifier
+            and isinstance(value, str)
+            and value[-1] in MODIFIER_MUL
+        ):
+            modifier = value
+            value = _SENTINEL
 
-    def __repr__(self) -> str_:
-        return datetime_.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+        if modifier is None:
+            modifier = 0
 
+        if isinstance(modifier, str):
+            modifier_mul: int = 1
+            modifier_mul_str = modifier[-1]
 
-class utcnow_(_baseclass):
-    now = type("now", (now_,), {})()
-
-    def __new__(cls, *args: Any) -> utcnow_:
-        result = object.__new__(cls, *args)
-
-        for attr in dir(cls):
-            if any(
-                (
-                    attr.startswith("_"),
-                    not callable(getattr(result, attr)),
-                    not isinstance(getattr(result, attr), FunctionType),
-                    "." not in getattr(getattr(result, attr), "__qualname__", "."),
-                    getattr(getattr(result, attr), "__qualname__", ".").rsplit(".", 1)[-1] != attr,
-                )
+            if (
+                len(modifier) > 1
+                and modifier_mul_str in MODIFIER_MUL
+                and (modifier[-2].isdigit() or modifier[-2] == ".")
             ):
+                modifier = modifier[:-1]
+                modifier_mul = MODIFIER_MUL[modifier_mul_str]
+
+            if "." in modifier:
+                modifier = float(modifier) * modifier_mul
+            else:
+                modifier = int(modifier) * modifier_mul
+
+        if value == "now":
+            value = _SENTINEL
+
+        return value, modifier
+
+    @functools.lru_cache(maxsize=128, typed=True)
+    def _transform_value(value: Union[str, datetime_, object, int, float, Decimal, Real]) -> str_:
+        """Transforms the input value to a timestamp string in RFC3339 format.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats.
+
+        Returns:
+            The transformed value as a string in RFC3339 format.
+        """
+        str_value: str_
+        try:
+            if isinstance(value, str):
+                str_value = value.strip()
+            elif isinstance(value, (int, float)):
+                return datetime_.fromtimestamp(value, tz=UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+            elif isinstance(value, (Decimal, Real)):
+                str_value = (
+                    datetime_.fromtimestamp(float(value), tz=UTC)
+                    .isoformat(timespec="microseconds")
+                    .replace("+00:00", "Z")
+                )
+            else:
+                str_value = str_(value).strip()
+
+            if (
+                str_value
+                and len(str_value) <= 21
+                and "T" not in str_value
+                and ":" not in str_value
+                and "/" not in str_value
+                and str_value.count("-") <= 1
+                and _is_numeric(str_value)
+            ):
+                str_value = (
+                    datetime_.fromtimestamp(float(str_value), tz=UTC)
+                    .isoformat(timespec="microseconds")
+                    .replace("+00:00", "Z")
+                )
+        except Exception:
+            raise ValueError(
+                f"The input value '{value}' (type: {value.__class__}) does not match allowed input formats"
+            )
+
+        if PREFERRED_FORMAT_REGEX.match(str_value):
+            if int(str_value[8:10]) >= 30 or (int(str_value[5:7]) == 2 and int(str_value[8:10]) >= 28):
+                try:
+                    dt_value = datetime_.strptime(str_value[0:10], "%Y-%m-%d")
+                except ValueError:
+                    raise ValueError(
+                        f"The input value '{value}' (type: {value.__class__}) does not match allowed input formats"
+                    )
+            return (str_value[:10] + "T" + str_value[11:]).upper().rstrip("Z").rsplit("+00:00")[0].rsplit("-00:00")[
+                0
+            ] + "Z"
+
+        ends_with_utc = False
+        if str_value.endswith(" UTC"):
+            str_value = str_value[0:-4]
+            ends_with_utc = True
+
+        for format_ in _ACCEPTED_INPUT_FORMAT_VALUES:
+            try:
+                dt_value = datetime_.strptime(str_value, format_)
+            except ValueError:
                 continue
 
-            func = getattr(result, attr)
-            func.__qualname__ = attr
+            if ends_with_utc and dt_value.tzinfo:
+                raise ValueError(
+                    f"The input value '{value}' (type: {value.__class__}) uses double timezone declaration: 'UTC' and '{dt_value.tzinfo}'"
+                )
 
-        return result
-
-    @staticmethod
-    def as_string(
-        value: Union[str_, datetime_, object, int, float, Decimal, Real] = _SENTINEL,
-        modifier: Optional[Union[str_, int, float]] = 0,
-    ) -> str_:
-        """Transforms the input value to a timestamp string in RFC3339 format.
-
-        Args:
-            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
-            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
-                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
-                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
-
-        Returns:
-            The transformed value as a string in RFC3339 format.
-
-        Raises:
-            ValueError: If the input value does not match allowed input formats.
-
-        Examples:
-            >>> import utcnow
-            >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00")
-            "2023-09-07T02:18:00.000000Z"
-            >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00", "+7d")
-            "2023-09-14T02:18:00.000000Z"
-            >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00+02:00")
-            "2023-09-07T00:18:00.000000Z"
-            >>> utcnow.rfc3339_timestamp(1693005993.285967)
-            "2023-08-25T23:26:33.285967Z"
-            >>> from datetime import datetime, timezone, timedelta
-            >>> tz = timezone(timedelta(hours=2, minutes=0))
-            >>> dt = datetime(2023, 4, 30, 8, 0, 0, tzinfo=tz)
-            >>> utcnow.rfc3339_timestamp(dt)
-            "2023-04-30T06:00:00.000000Z"
-        """
-        value, modifier = _init_modifier(value, modifier)
-
-        if value is _SENTINEL:
-            return (
-                (datetime_.now(UTC) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier))
-                .isoformat(timespec="microseconds")
-                .replace("+00:00", "Z")
+            break
+        else:
+            raise ValueError(
+                f"The input value '{value}' (type: {value.__class__}) does not match allowed input formats"
             )
-        return _transform_value(value) if not modifier else _transform_value(_timestamp_to_unixtime(value) + modifier)
 
-    @staticmethod
-    def as_datetime(
-        value: Union[str_, datetime_, object, int, float, Decimal, Real] = _SENTINEL,
-        modifier: Optional[Union[str_, int, float]] = 0,
-    ) -> datetime_:
+        if not dt_value.tzinfo:
+            # Timezone declaration missing, skipping tz application and blindly assuming UTC
+            return dt_value.isoformat(timespec="microseconds") + "Z"
+
+        return dt_value.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+    @functools.lru_cache(maxsize=128)
+    def _timestamp_to_datetime(value: str) -> datetime_:
         """Transforms the input value to a datetime object.
 
         Args:
-            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
-            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
-                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
-                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+            value: A value representing a timestamp in any of the allowed input formats.
 
         Returns:
             The transformed value as a datetime object.
-
-        Raises:
-            ValueError: If the input value does not match allowed input formats.
-
-        Examples:
-            >>> import utcnow
-            >>> utcnow.as_datetime("2023-08-01 12:10:59.123456+02:00")
-            datetime.datetime(2023, 8, 1, 10, 10, 59, 123456, tzinfo=datetime.timezone.utc)
         """
-        value, modifier = _init_modifier(value, modifier)
+        value = _transform_value(value)
+        return datetime_.strptime(value, "%Y-%m-%dT%H:%M:%S.%f%z")
 
-        if value is _SENTINEL:
-            # 'datetime.datetime.now(UTC)' is faster than (deprecated) 'datetime.datetime.utcnow().replace(tzinfo=UTC)'
-            return datetime_.now(UTC) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier)
-        return _timestamp_to_datetime(value) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier)
-
-    @staticmethod
-    def as_unixtime(
-        value: Union[str_, datetime_, object, int, float, Decimal, Real] = _SENTINEL,
-        modifier: Optional[Union[str_, int, float]] = 0,
-    ) -> float:
+    @functools.lru_cache(maxsize=128)
+    def _timestamp_to_unixtime(value: str) -> float:
         """Transforms the input value to a float value representing a timestamp as unixtime.
 
         Args:
-            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
-            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
-                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
-                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+            value: A value representing a timestamp in any of the allowed input formats.
 
         Returns:
             The transformed value in unixtime (float).
-
-        Raises:
-            ValueError: If the input value does not match allowed input formats.
-
-        Examples:
-            >>> import utcnow
-            >>> utcnow.as_unixtime("1970-01-01T00:00:00.000000Z")
-            0.0
-            >>> utcnow.as_unixtime("1970-01-01T00:00:00.000000Z", "+24h")
-            86400.0
-            >>> utcnow.as_unixtime("2022-01-01 00:00:00.123456+00:00")
-            1640995200.123456
         """
-        value, modifier = _init_modifier(value, modifier)
+        return _timestamp_to_datetime(value).timestamp()
 
-        if value is _SENTINEL:
-            return time_.time() + modifier
-        return _timestamp_to_unixtime(value) + modifier
-
-    @staticmethod
-    def as_protobuf(
-        value: Union[str_, datetime_, object, int, float, Decimal, Real] = _SENTINEL,
-        modifier: Optional[Union[str_, int, float]] = 0,
-    ) -> TimestampProtobufMessage:
-        """Transforms the input value to a google.protobuf.Timestamp protobuf message.
+    @functools.lru_cache(maxsize=128)
+    def _unixtime_to_protobuf(unixtime_value: Union[int, float]) -> TimestampProtobufMessage:
+        """Transforms the unix timestamp input value to a google.protobuf.Timestamp protobuf message.
 
         Args:
-            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
-            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
-                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
-                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+            unixtime_value: A timestamp in unixtime format (float).
 
         Returns:
             The transformed value as a google.protobuf.Timestamp message.
-
-        Raises:
-            ValueError: If the input value does not match allowed input formats.
-
-        Examples:
-            >>> import utcnow
-            >>> utcnow.as_protobuf("2022-01-01 00:00:00.123456+00:00")
-            seconds: 1640995200
-            nanos: 123456000
-            >>> utcnow.as_protobuf(1234567890.05, modifier=-0.1)
-            seconds: 1234567889
-            nanos: 950000000
         """
-        value, modifier = _init_modifier(value, modifier)
+        seconds = int(unixtime_value)
+        nanos = round(int((unixtime_value - seconds) * 1e6)) * 1000
+        if nanos < 0:
+            seconds -= 1
+            nanos += 1_000_000_000
+        return TimestampProtobufMessage(
+            seconds=seconds,
+            nanos=nanos,
+        )
 
-        if value is _SENTINEL:
-            unixtime_value = time_.time() + modifier
-            seconds = int(unixtime_value)
-            nanos = round(int((unixtime_value - seconds) * 1e6)) * 1000
-            if nanos < 0:
-                seconds -= 1
-                nanos += 1_000_000_000
-            return TimestampProtobufMessage(
-                seconds=seconds,
-                nanos=nanos,
-            )
-
-        return _unixtime_to_protobuf(_timestamp_to_unixtime(value) + modifier)
-
-    @staticmethod
-    def timediff(
-        begin: Union[str_, datetime_, object, int, float, Decimal, Real],
-        end: Union[str_, datetime_, object, int, float, Decimal, Real],
-        unit: str_ = "seconds",
-    ) -> float:
-        """Calculate the time difference between two timestamps.
+    @functools.lru_cache(maxsize=128)
+    def _timezone_from_string(value: str) -> Optional[tzinfo_]:
+        """Converts a string to a timezone object.
 
         Args:
-            begin: The beginning timestamp. Can be a string, datetime object, or a numeric unixtime value.
-            end: The ending timestamp. Can be a string, datetime object, or a numeric unixtime value.
-            unit: The unit of time to return the difference in. Defaults to "seconds".
+            value: A string representing a 0-offset timezone (UTC) or a timezone string as an offset (for example: +HH:mm).
 
         Returns:
-            The time difference between the two timestamps in the specified unit.
-
-        Raises:
-            ValueError: If an unknown unit is specified.
-
-        Examples:
-            >>> import utcnow
-            >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-01 00:00:10")
-            10.0
-            >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-01 00:01:00", unit="minutes")
-            1.0
-            >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-02 00:00:00", unit="days")
-            1.0
-            >>> utcnow.timediff("2022-01-01T00:00:00.000000Z", "2022-01-02T06:00:00.000000Z", unit="days")
-            1.25
-            >>> utcnow.timediff(0, 7200, unit="hours")
-            2.0
+            A timezone object if the string represents a valid timezone, otherwise None.
         """
-        delta = _timestamp_to_datetime(end) - _timestamp_to_datetime(begin)
-        unit = unit.lower()
+        if value.upper() in (
+            "UTC",
+            "GMT",
+            "UTC+0",
+            "UTC-0",
+            "GMT+0",
+            "GMT-0",
+            "Z",
+            "ZULU",
+            "00:00",
+            "+00:00",
+            "-00:00",
+            "0000",
+            "+0000",
+            "-0000",
+        ):
+            return UTC
 
-        if unit in ("seconds", "second", "sec", "s"):
-            return delta.total_seconds()
-        if unit in ("minutes", "minute", "min", "m"):
-            return delta.total_seconds() / 60
-        if unit in ("hours", "hour", "h"):
-            return delta.total_seconds() / 3600
-        if unit in ("days", "day", "d"):
-            return delta.total_seconds() / 86400
-        if unit in ("weeks", "week", "w"):
-            return delta.total_seconds() / (86400 * 7)
+        if value and value[0] in ("+", "-"):
+            m = re.match(r"^[+-]([0-9]{2}):?([0-9]{2})$", value)
+            if not m:
+                return None
 
-        raise ValueError(f"Unknown unit '{unit}' for utcnow.timediff")
+            modifier = 1 if value[0] == "+" else -1
 
-    @staticmethod
-    def as_date_string(
-        value: Union[str_, datetime_, object, int, float, Decimal, Real] = _SENTINEL,
-        tz: Optional[Union[str_, tzinfo_]] = None,
-    ) -> str_:
-        """Transforms the input value to a string representing a date (YYYY-mm-dd) without timespec or timezone.
+            td = timedelta_(hours=int(m.group(1)), minutes=int(m.group(2)))
+            if td.days == 1 and td == timedelta_(days=1):
+                td = timedelta_(days=1, microseconds=-1)
 
-        Args:
-            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
-            tz: An optional timezone for which the date is represented related to the input value.
-                If not specified, UTC timezone will be applied.
+            return timezone_(modifier * td)
 
-        Returns:
-            A string representing a date (YYYY-mm-dd) without timespec or timezone.
+        return None
 
-        Raises:
-            ValueError: If the input value does not match allowed input formats.
+    class _metaclass(type):
+        def __new__(cls: Type[_metaclass], name: str, bases: Tuple[type, ...], attributedict: Dict) -> _metaclass:
+            result = cast(Type["_baseclass"], super().__new__(cls, name, bases, dict(attributedict)))
 
-        Examples:
-            >>> import utcnow
-            >>> utcnow.as_date_string("2023-09-07 02:18:00")
-            "2023-09-07"
-            >>> utcnow.as_date_string("2020-01-01T00:00:00.000000Z")
-            "2020-01-01"
-            >>> utcnow.as_date_string("2020-01-01T00:00:00.000000+02:00")
-            "2019-12-31"
-            >>> utcnow.as_date_string("2020-01-01T00:00:00.000000+02:00", "+02:00")
-            "2020-01-01"
-            >>> utcnow.as_date_string(1234567890.123456)
-            "2009-02-13"
-            >>> utcnow.as_date_string(0)
-            "1970-01-01"
-            >>> utcnow.as_date_string()
-            "2023-09-07"  # current date
-        """
-        date_tz: Optional[tzinfo_] = None
+            return result
 
-        if not tz:
-            date_tz = UTC
-        elif isinstance(tz, tzinfo_):
-            date_tz = tz
-        elif isinstance(tz, str_):
-            date_tz = _timezone_from_string(tz)
+    class _baseclass(metaclass=_metaclass):
+        def __init__(self) -> None:
+            pass
 
-        if not date_tz:
-            raise ValueError(
-                f"Unknown timezone value '{tz}' (type: {tz.__class__.__name__}) - use value of type 'datetime.tzinfo' or an utcoffset string value"
+        def __call__(
+            self,
+            value: Union[str, datetime_, object, int, float, Decimal, Real] = _SENTINEL,
+            modifier: Optional[Union[str, int, float]] = 0,
+        ) -> str_:
+            """Transforms the input value to a timestamp string in RFC3339 format.
+
+            Args:
+                value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+                modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                    Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                    Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+            Returns:
+                The transformed value as a string in RFC3339 format.
+
+            Raises:
+                ValueError: If the input value does not match allowed input formats.
+            """
+            value, modifier = _init_modifier(value, modifier)
+
+            if value is _SENTINEL:
+                return (
+                    (datetime_.now(UTC) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier))
+                    .isoformat(timespec="microseconds")
+                    .replace("+00:00", "Z")
+                )
+            return (
+                _transform_value(value) if not modifier else _transform_value(_timestamp_to_unixtime(value) + modifier)
             )
 
-        if value is _SENTINEL or value == "now":
-            return datetime_.now(date_tz).date().isoformat()
+    class now_(_baseclass):
+        def __new__(cls, *args: Any) -> now_:
+            result = object.__new__(cls, *args)
+            return result
 
-        return _timestamp_to_datetime(value).astimezone(date_tz).date().isoformat()
+        def __str__(self) -> str_:
+            return datetime_.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
 
-    as_str = as_string
-    as_rfc3339 = as_string
-    to_string = as_string
-    to_str = as_string
-    to_rfc3339 = as_string
-    get_string = as_string
-    get_str = as_string
-    get_rfc3339 = as_string
-    get = as_string
-    string = as_string
-    str = as_string
-    rfc3339 = as_string
-    timestamp_rfc3339 = as_string
-    ts_rfc3339 = as_string
-    rfc3339_timestamp = as_string
-    rfc3339_ts = as_string
-    utcnow_rfc3339 = as_string
-    rfc3339_utcnow = as_string
-    now_rfc3339 = as_string
-    rfc3339_now = as_string
-    get_now = as_string
+        def __repr__(self) -> str_:
+            return datetime_.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
 
-    as_date = as_datetime
-    as_dt = as_datetime
-    to_datetime = as_datetime
-    to_date = as_datetime
-    to_dt = as_datetime
-    get_datetime = as_datetime
-    get_date = as_datetime
-    get_dt = as_datetime
-    datetime = as_datetime
-    date = as_datetime
-    dt = as_datetime
+    class utcnow_(_baseclass):
+        now = type("now", (now_,), {})()
 
-    as_unix = as_unixtime
-    as_time = as_unixtime
-    as_timestamp = as_unixtime
-    as_ut = as_unixtime
-    as_ts = as_unixtime
-    as_float = as_unixtime
-    to_unixtime = as_unixtime
-    to_unix = as_unixtime
-    to_time = as_unixtime
-    to_timestamp = as_unixtime
-    to_ut = as_unixtime
-    to_ts = as_unixtime
-    to_float = as_unixtime
-    get_unixtime = as_unixtime
-    get_unix = as_unixtime
-    get_time = as_unixtime
-    get_timestamp = as_unixtime
-    get_ut = as_unixtime
-    get_ts = as_unixtime
-    get_float = as_unixtime
-    unixtime = as_unixtime
-    unix = as_unixtime
-    time = as_unixtime
-    timestamp = as_unixtime
-    ut = as_unixtime
-    ts = as_unixtime
+        def __new__(cls, *args: Any) -> utcnow_:
+            result = object.__new__(cls, *args)
 
-    as_proto = as_protobuf
-    as_protobuf_timestamp = as_protobuf
-    as_proto_timestamp = as_protobuf
-    as_pb = as_protobuf
-    to_protobuf = as_protobuf
-    to_proto = as_protobuf
-    to_protobuf_timestamp = as_protobuf
-    to_proto_timestamp = as_protobuf
-    to_pb = as_protobuf
-    get_protobuf = as_protobuf
-    get_proto = as_protobuf
-    get_protobuf_timestamp = as_protobuf
-    get_proto_timestamp = as_protobuf
-    get_pb = as_protobuf
-    protobuf = as_protobuf
-    proto = as_protobuf
-    protobuf_timestamp = as_protobuf
-    proto_timestamp = as_protobuf
-    pb = as_protobuf
+            for attr in dir(cls):
+                if any(
+                    (
+                        attr.startswith("_"),
+                        not callable(getattr(result, attr)),
+                        not isinstance(getattr(result, attr), FunctionType),
+                        "." not in getattr(getattr(result, attr), "__qualname__", "."),
+                        getattr(getattr(result, attr), "__qualname__", ".").rsplit(".", 1)[-1] != attr,
+                    )
+                ):
+                    continue
 
-    time_diff = timediff
-    diff = timediff
-    timedelta = timediff
-    delta = timediff
+                func = getattr(result, attr)
+                func.__qualname__ = attr
 
-    as_datestring = as_date_string
-    as_date_str = as_date_string
-    as_datestr = as_date_string
-    to_date_string = as_date_string
-    to_datestring = as_date_string
-    to_date_str = as_date_string
-    to_datestr = as_date_string
-    get_date_string = as_date_string
-    get_datestring = as_date_string
-    get_datestr = as_date_string
-    get_date_string = as_date_string
-    get_today = as_date_string
-    get_today_date = as_date_string
-    get_todays_date = as_date_string
-    get_date_today = as_date_string
-    date_today = as_date_string
-    today_date = as_date_string
-    todays_date = as_date_string
-    today = as_date_string
-    date_string = as_date_string
-    datestring = as_date_string
-    date_str = as_date_string
-    datestr = as_date_string
+            return result
 
-    def __str__(self) -> str_:
-        return self.as_string()
+        @staticmethod
+        def as_string(
+            value: Union[str, datetime_, object, int, float, Decimal, Real] = _SENTINEL,
+            modifier: Optional[Union[str, int, float]] = 0,
+        ) -> str_:
+            """Transforms the input value to a timestamp string in RFC3339 format.
 
-    def __repr__(self) -> str_:
-        return self.as_string()
+            Args:
+                value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+                modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                    Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                    Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
 
+            Returns:
+                The transformed value as a string in RFC3339 format.
 
-# class module_(utcnow_):
-#     __version__: str_ = __version__  # noqa
-#     __version_info__: Tuple[Union[int, str_], ...] = __version_info__
-#     __author__: str_ = __author__
-#     __email__: str_ = __email__
-#
-#     utcnow = type("utcnow", (utcnow_,), {})()
-#
-#     def __new__(cls, *args: Any) -> module_:
-#         result = object.__new__(cls, *args)
-#
-#         setattr(result, "now", result.utcnow)
-#
-#         return result
+            Raises:
+                ValueError: If the input value does not match allowed input formats.
 
+            Examples:
+                >>> import utcnow
+                >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00")
+                "2023-09-07T02:18:00.000000Z"
+                >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00", "+7d")
+                "2023-09-14T02:18:00.000000Z"
+                >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00+02:00")
+                "2023-09-07T00:18:00.000000Z"
+                >>> utcnow.rfc3339_timestamp(1693005993.285967)
+                "2023-08-25T23:26:33.285967Z"
+                >>> from datetime import datetime, timezone, timedelta
+                >>> tz = timezone(timedelta(hours=2, minutes=0))
+                >>> dt = datetime(2023, 4, 30, 8, 0, 0, tzinfo=tz)
+                >>> utcnow.rfc3339_timestamp(dt)
+                "2023-04-30T06:00:00.000000Z"
+            """
+            value, modifier = _init_modifier(value, modifier)
 
-utcnow = now = type("utcnow", (utcnow_,), {})()
+            if value is _SENTINEL:
+                return (
+                    (datetime_.now(UTC) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier))
+                    .isoformat(timespec="microseconds")
+                    .replace("+00:00", "Z")
+                )
+            return (
+                _transform_value(value) if not modifier else _transform_value(_timestamp_to_unixtime(value) + modifier)
+            )
 
-rfc3339_timestamp = utcnow.rfc3339_timestamp
-as_datetime = utcnow.as_datetime
-as_unixtime = utcnow.as_unixtime
-as_protobuf = utcnow.as_protobuf
-as_date_string = utcnow.as_date_string
-today = utcnow.today
-timediff = utcnow.timediff
+        @staticmethod
+        def as_datetime(
+            value: Union[str, datetime_, object, int, float, Decimal, Real] = _SENTINEL,
+            modifier: Optional[Union[str, int, float]] = 0,
+        ) -> datetime_:
+            """Transforms the input value to a datetime object.
 
-# utcnow_instance = type("utcnow", (module_,), {})()
-# utcnow = utcnow_instance.utcnow
-# now = utcnow
-#
-# as_string = utcnow_instance.as_string
-# as_str = as_string
-# as_rfc3339 = as_string
-# to_string = as_string
-# to_str = as_string
-# to_rfc3339 = as_string
-# get_string = as_string
-# get_str = as_string
-# get_rfc3339 = as_string
-# get = as_string
-# string = as_string
-# str = as_string
-# rfc3339 = as_string
-# timestamp_rfc3339 = as_string
-# ts_rfc3339 = as_string
-# rfc3339_timestamp = as_string
-# rfc3339_ts = as_string
-# utcnow_rfc3339 = as_string
-# rfc3339_utcnow = as_string
-# now_rfc3339 = as_string
-# rfc3339_now = as_string
-# get_now = as_string
-#
-# as_datetime = utcnow_instance.as_datetime
-# as_date = as_datetime
-# as_dt = as_datetime
-# to_datetime = as_datetime
-# to_date = as_datetime
-# to_dt = as_datetime
-# get_datetime = as_datetime
-# get_date = as_datetime
-# get_dt = as_datetime
-# datetime = as_datetime
-# date = as_datetime
-# dt = as_datetime
-#
-# as_unixtime = utcnow_instance.as_unixtime
-# as_unix = as_unixtime
-# as_time = as_unixtime
-# as_timestamp = as_unixtime
-# as_ut = as_unixtime
-# as_ts = as_unixtime
-# as_float = as_unixtime
-# to_unixtime = as_unixtime
-# to_unix = as_unixtime
-# to_time = as_unixtime
-# to_timestamp = as_unixtime
-# to_ut = as_unixtime
-# to_ts = as_unixtime
-# to_float = as_unixtime
-# get_unixtime = as_unixtime
-# get_unix = as_unixtime
-# get_time = as_unixtime
-# get_timestamp = as_unixtime
-# get_ut = as_unixtime
-# get_ts = as_unixtime
-# get_float = as_unixtime
-# unixtime = as_unixtime
-# unix = as_unixtime
-# time = as_unixtime
-# timestamp = as_unixtime
-# ut = as_unixtime
-# ts = as_unixtime
-#
-# as_protobuf = utcnow_instance.as_protobuf
-# as_proto = as_protobuf
-# as_protobuf_timestamp = as_protobuf
-# as_proto_timestamp = as_protobuf
-# as_pb = as_protobuf
-# to_protobuf = as_protobuf
-# to_proto = as_protobuf
-# to_protobuf_timestamp = as_protobuf
-# to_proto_timestamp = as_protobuf
-# to_pb = as_protobuf
-# get_protobuf = as_protobuf
-# get_proto = as_protobuf
-# get_protobuf_timestamp = as_protobuf
-# get_proto_timestamp = as_protobuf
-# get_pb = as_protobuf
-# protobuf = as_protobuf
-# proto = as_protobuf
-# protobuf_timestamp = as_protobuf
-# proto_timestamp = as_protobuf
-# pb = as_protobuf
-#
-# timediff = utcnow_instance.timediff
-# time_diff = timediff
-# diff = timediff
-# timedelta = timediff
-# delta = timediff
-#
-# as_date_string = utcnow_instance.as_date_string
-# as_datestring = as_date_string
-# as_date_str = as_date_string
-# as_datestr = as_date_string
-# to_date_string = as_date_string
-# to_datestring = as_date_string
-# to_date_str = as_date_string
-# to_datestr = as_date_string
-# get_date_string = as_date_string
-# get_datestring = as_date_string
-# get_date_str = as_date_string
-# get_datestr = as_date_string
-# get_today = as_date_string
-# get_today_date = as_date_string
-# get_todays_date = as_date_string
-# get_date_today = as_date_string
-# date_today = as_date_string
-# today_date = as_date_string
-# todays_date = as_date_string
-# today = as_date_string
-# date_string = as_date_string
-# datestring = as_date_string
-# date_str = as_date_string
-# datestr = as_date_string
+            Args:
+                value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+                modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                    Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                    Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
 
-__all__ = [
-    "__version__",
-    "__version_info__",
-    "__author__",
-    "__email__",
-    "rfc3339_timestamp",
-    "as_datetime",
-    "as_unixtime",
-    "as_protobuf",
-    "as_date_string",
-    "today",
-    "timediff",
-    "utcnow",
-    "now",
-]
+            Returns:
+                The transformed value as a datetime object.
 
-# __all__ = [
-#     "__version__",
-#     "__version_info__",
-#     "__author__",
-#     "__email__",
-#     "utcnow",
-#     "now",
-#     "as_string",
-#     "as_str",
-#     "as_rfc3339",
-#     "to_string",
-#     "to_str",
-#     "to_rfc3339",
-#     "get_string",
-#     "get_str",
-#     "get_rfc3339",
-#     "get",
-#     "string",
-#     "str",
-#     "rfc3339",
-#     "timestamp_rfc3339",
-#     "ts_rfc3339",
-#     "rfc3339_timestamp",
-#     "rfc3339_ts",
-#     "utcnow_rfc3339",
-#     "rfc3339_utcnow",
-#     "now_rfc3339",
-#     "rfc3339_now",
-#     "get_now",
-#     "as_datetime",
-#     "as_date",
-#     "as_dt",
-#     "to_datetime",
-#     "to_date",
-#     "to_dt",
-#     "get_datetime",
-#     "get_date",
-#     "get_dt",
-#     "datetime",
-#     "date",
-#     "dt",
-#     "as_unixtime",
-#     "as_unix",
-#     "as_time",
-#     "as_timestamp",
-#     "as_ut",
-#     "as_ts",
-#     "as_float",
-#     "to_unixtime",
-#     "to_unix",
-#     "to_time",
-#     "to_timestamp",
-#     "to_ut",
-#     "to_ts",
-#     "to_float",
-#     "get_unixtime",
-#     "get_unix",
-#     "get_time",
-#     "get_timestamp",
-#     "get_ut",
-#     "get_ts",
-#     "get_float",
-#     "unixtime",
-#     "unix",
-#     "time",
-#     "timestamp",
-#     "ut",
-#     "ts",
-#     "timediff",
-#     "time_diff",
-#     "diff",
-#     "timedelta",
-#     "delta",
-#     "as_date_string",
-#     "as_datestring",
-#     "as_date_str",
-#     "as_datestr",
-#     "to_date_string",
-#     "to_datestring",
-#     "to_date_str",
-#     "to_datestr",
-#     "get_date_string",
-#     "get_datestring",
-#     "get_date_str",
-#     "get_datestr",
-#     "get_today",
-#     "get_today_date",
-#     "get_todays_date",
-#     "get_date_today",
-#     "date_today",
-#     "today_date",
-#     "todays_date",
-#     "today",
-#     "date_string",
-#     "datestring",
-#     "date_str",
-#     "datestr",
-# ]
+            Raises:
+                ValueError: If the input value does not match allowed input formats.
 
-original_module = sys.modules[__name__]  # noqa
+            Examples:
+                >>> import utcnow
+                >>> utcnow.as_datetime("2023-08-01 12:10:59.123456+02:00")
+                datetime.datetime(2023, 8, 1, 10, 10, 59, 123456, tzinfo=datetime.timezone.utc)
+            """
+            value, modifier = _init_modifier(value, modifier)
 
+            if value is _SENTINEL:
+                # 'datetime.datetime.now(UTC)' is faster than (deprecated) 'datetime.datetime.utcnow().replace(tzinfo=UTC)'
+                return datetime_.now(UTC) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier)
+            return _timestamp_to_datetime(value) if not modifier else datetime_.now(UTC) + timedelta_(seconds=modifier)
 
-class ModuleValue(int):
-    def __eq__(self, other: Any) -> bool:
-        if other is None or other is False:
-            return True
-        return super().__eq__(other)
+        @staticmethod
+        def as_unixtime(
+            value: Union[str, datetime_, object, int, float, Decimal, Real] = _SENTINEL,
+            modifier: Optional[Union[str, int, float]] = 0,
+        ) -> float:
+            """Transforms the input value to a float value representing a timestamp as unixtime.
 
-    def __bool__(self) -> bool:
-        return False
+            Args:
+                value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+                modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                    Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                    Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
 
-    def __instancecheck__(self, instance: Any) -> bool:
-        if instance is None.__class__ or instance is None or isinstance(instance, None.__class__):
-            return True
-        if isinstance(instance, str_):
-            return False
-        return False
+            Returns:
+                The transformed value in unixtime (float).
 
-    def __add__(self, value: Any) -> Any:
-        if value is None:
-            return self
-        if isinstance(value, str_):
-            return str_(self) + str_(value)
+            Raises:
+                ValueError: If the input value does not match allowed input formats.
 
-    def __repr__(self) -> str_:
-        return __name__
+            Examples:
+                >>> import utcnow
+                >>> utcnow.as_unixtime("1970-01-01T00:00:00.000000Z")
+                0.0
+                >>> utcnow.as_unixtime("1970-01-01T00:00:00.000000Z", "+24h")
+                86400.0
+                >>> utcnow.as_unixtime("2022-01-01 00:00:00.123456+00:00")
+                1640995200.123456
+            """
+            value, modifier = _init_modifier(value, modifier)
 
-    def __str__(self) -> str_:
-        return __name__
+            if value is _SENTINEL:
+                return time_.time() + modifier
+            return _timestamp_to_unixtime(value) + modifier
 
+        @staticmethod
+        def as_protobuf(
+            value: Union[str, datetime_, object, int, float, Decimal, Real] = _SENTINEL,
+            modifier: Optional[Union[str, int, float]] = 0,
+        ) -> TimestampProtobufMessage:
+            """Transforms the input value to a google.protobuf.Timestamp protobuf message.
 
-def staticmethod_(func: CT) -> CT:
-    return cast(CT, staticmethod(func))
+            Args:
+                value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+                modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                    Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                    Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
 
+            Returns:
+                The transformed value as a google.protobuf.Timestamp message.
 
-class ReplacementModuleType:
-    __name__: str_
-    __all__: List[str_] = [
+            Raises:
+                ValueError: If the input value does not match allowed input formats.
+
+            Examples:
+                >>> import utcnow
+                >>> utcnow.as_protobuf("2022-01-01 00:00:00.123456+00:00")
+                seconds: 1640995200
+                nanos: 123456000
+                >>> utcnow.as_protobuf(1234567890.05, modifier=-0.1)
+                seconds: 1234567889
+                nanos: 950000000
+            """
+            value, modifier = _init_modifier(value, modifier)
+
+            if value is _SENTINEL:
+                unixtime_value = time_.time() + modifier
+                seconds = int(unixtime_value)
+                nanos = round(int((unixtime_value - seconds) * 1e6)) * 1000
+                if nanos < 0:
+                    seconds -= 1
+                    nanos += 1_000_000_000
+                return TimestampProtobufMessage(
+                    seconds=seconds,
+                    nanos=nanos,
+                )
+
+            return _unixtime_to_protobuf(_timestamp_to_unixtime(value) + modifier)
+
+        @staticmethod
+        def timediff(
+            begin: Union[str, datetime_, object, int, float, Decimal, Real],
+            end: Union[str, datetime_, object, int, float, Decimal, Real],
+            unit: str_ = "seconds",
+        ) -> float:
+            """Calculate the time difference between two timestamps.
+
+            Args:
+                begin: The beginning timestamp. Can be a string, datetime object, or a numeric unixtime value.
+                end: The ending timestamp. Can be a string, datetime object, or a numeric unixtime value.
+                unit: The unit of time to return the difference in. Defaults to "seconds".
+
+            Returns:
+                The time difference between the two timestamps in the specified unit.
+
+            Raises:
+                ValueError: If an unknown unit is specified.
+
+            Examples:
+                >>> import utcnow
+                >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-01 00:00:10")
+                10.0
+                >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-01 00:01:00", unit="minutes")
+                1.0
+                >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-02 00:00:00", unit="days")
+                1.0
+                >>> utcnow.timediff("2022-01-01T00:00:00.000000Z", "2022-01-02T06:00:00.000000Z", unit="days")
+                1.25
+                >>> utcnow.timediff(0, 7200, unit="hours")
+                2.0
+            """
+            delta = _timestamp_to_datetime(end) - _timestamp_to_datetime(begin)
+            unit = unit.lower()
+
+            if unit in ("seconds", "second", "sec", "s"):
+                return delta.total_seconds()
+            if unit in ("minutes", "minute", "min", "m"):
+                return delta.total_seconds() / 60
+            if unit in ("hours", "hour", "h"):
+                return delta.total_seconds() / 3600
+            if unit in ("days", "day", "d"):
+                return delta.total_seconds() / 86400
+            if unit in ("weeks", "week", "w"):
+                return delta.total_seconds() / (86400 * 7)
+
+            raise ValueError(f"Unknown unit '{unit}' for utcnow.timediff")
+
+        @staticmethod
+        def as_date_string(
+            value: Union[str, datetime_, object, int, float, Decimal, Real] = _SENTINEL,
+            tz: Optional[Union[str, tzinfo_]] = None,
+        ) -> str_:
+            """Transforms the input value to a string representing a date (YYYY-mm-dd) without timespec or timezone.
+
+            Args:
+                value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+                tz: An optional timezone for which the date is represented related to the input value.
+                    If not specified, UTC timezone will be applied.
+
+            Returns:
+                A string representing a date (YYYY-mm-dd) without timespec or timezone.
+
+            Raises:
+                ValueError: If the input value does not match allowed input formats.
+
+            Examples:
+                >>> import utcnow
+                >>> utcnow.as_date_string("2023-09-07 02:18:00")
+                "2023-09-07"
+                >>> utcnow.as_date_string("2020-01-01T00:00:00.000000Z")
+                "2020-01-01"
+                >>> utcnow.as_date_string("2020-01-01T00:00:00.000000+02:00")
+                "2019-12-31"
+                >>> utcnow.as_date_string("2020-01-01T00:00:00.000000+02:00", "+02:00")
+                "2020-01-01"
+                >>> utcnow.as_date_string(1234567890.123456)
+                "2009-02-13"
+                >>> utcnow.as_date_string(0)
+                "1970-01-01"
+                >>> utcnow.as_date_string()
+                "2023-09-07"  # current date
+            """
+            date_tz: Optional[tzinfo_] = None
+
+            if not tz:
+                date_tz = UTC
+            elif isinstance(tz, tzinfo_):
+                date_tz = tz
+            elif isinstance(tz, str):
+                date_tz = _timezone_from_string(tz)
+
+            if not date_tz:
+                raise ValueError(
+                    f"Unknown timezone value '{tz}' (type: {tz.__class__.__name__}) - use value of type 'datetime.tzinfo' or an utcoffset string value"
+                )
+
+            if value is _SENTINEL or value == "now":
+                return datetime_.now(date_tz).date().isoformat()
+
+            return _timestamp_to_datetime(value).astimezone(date_tz).date().isoformat()
+
+        as_str = as_string
+        as_rfc3339 = as_string
+        to_string = as_string
+        to_str = as_string
+        to_rfc3339 = as_string
+        get_string = as_string
+        get_str = as_string
+        get_rfc3339 = as_string
+        get = as_string
+        string = as_string
+        str = as_string
+        rfc3339 = as_string
+        timestamp_rfc3339 = as_string
+        ts_rfc3339 = as_string
+        rfc3339_timestamp = as_string
+        rfc3339_ts = as_string
+        utcnow_rfc3339 = as_string
+        rfc3339_utcnow = as_string
+        now_rfc3339 = as_string
+        rfc3339_now = as_string
+        get_now = as_string
+
+        as_date = as_datetime
+        as_dt = as_datetime
+        to_datetime = as_datetime
+        to_date = as_datetime
+        to_dt = as_datetime
+        get_datetime = as_datetime
+        get_date = as_datetime
+        get_dt = as_datetime
+        datetime = as_datetime
+        date = as_datetime
+        dt = as_datetime
+
+        as_unix = as_unixtime
+        as_time = as_unixtime
+        as_timestamp = as_unixtime
+        as_ut = as_unixtime
+        as_ts = as_unixtime
+        as_float = as_unixtime
+        to_unixtime = as_unixtime
+        to_unix = as_unixtime
+        to_time = as_unixtime
+        to_timestamp = as_unixtime
+        to_ut = as_unixtime
+        to_ts = as_unixtime
+        to_float = as_unixtime
+        get_unixtime = as_unixtime
+        get_unix = as_unixtime
+        get_time = as_unixtime
+        get_timestamp = as_unixtime
+        get_ut = as_unixtime
+        get_ts = as_unixtime
+        get_float = as_unixtime
+        unixtime = as_unixtime
+        unix = as_unixtime
+        time = as_unixtime
+        timestamp = as_unixtime
+        ut = as_unixtime
+        ts = as_unixtime
+
+        as_proto = as_protobuf
+        as_protobuf_timestamp = as_protobuf
+        as_proto_timestamp = as_protobuf
+        as_pb = as_protobuf
+        to_protobuf = as_protobuf
+        to_proto = as_protobuf
+        to_protobuf_timestamp = as_protobuf
+        to_proto_timestamp = as_protobuf
+        to_pb = as_protobuf
+        get_protobuf = as_protobuf
+        get_proto = as_protobuf
+        get_protobuf_timestamp = as_protobuf
+        get_proto_timestamp = as_protobuf
+        get_pb = as_protobuf
+        protobuf = as_protobuf
+        proto = as_protobuf
+        protobuf_timestamp = as_protobuf
+        proto_timestamp = as_protobuf
+        pb = as_protobuf
+
+        time_diff = timediff
+        diff = timediff
+        timedelta = timediff
+        delta = timediff
+
+        as_datestring = as_date_string
+        as_date_str = as_date_string
+        as_datestr = as_date_string
+        to_date_string = as_date_string
+        to_datestring = as_date_string
+        to_date_str = as_date_string
+        to_datestr = as_date_string
+        get_date_string = as_date_string
+        get_datestring = as_date_string
+        get_datestr = as_date_string
+        get_date_string = as_date_string
+        get_today = as_date_string
+        get_today_date = as_date_string
+        get_todays_date = as_date_string
+        get_date_today = as_date_string
+        date_today = as_date_string
+        today_date = as_date_string
+        todays_date = as_date_string
+        today = as_date_string
+        date_string = as_date_string
+        datestring = as_date_string
+        date_str = as_date_string
+        datestr = as_date_string
+
+        def __str__(self) -> str_:
+            return self.as_string()
+
+        def __repr__(self) -> str_:
+            return self.as_string()
+
+    utcnow = now = type("utcnow", (utcnow_,), {})()
+
+    rfc3339_timestamp = utcnow.rfc3339_timestamp
+    as_datetime = utcnow.as_datetime
+    as_unixtime = utcnow.as_unixtime
+    as_protobuf = utcnow.as_protobuf
+    as_date_string = utcnow.as_date_string
+    today = utcnow.today
+    timediff = utcnow.timediff
+
+    __all__ = [
         "__version__",
         "__version_info__",
         "__author__",
@@ -1159,22 +876,32 @@ class ReplacementModuleType:
         "utcnow",
         "now",
     ]
-    __cached__: Any
-    __call__ = staticmethod_(utcnow.rfc3339_timestamp)
 
-    def __init__(self, name: str_, doc: Any) -> None:
-        ModuleType.__init__(cast(ModuleType, self), name, doc)
+    def staticmethod_(func: CT) -> CT:
+        return cast(CT, staticmethod(func))
 
-    def __repr__(self) -> str_:
+    code = """\
+def __repr__(self) -> str_:
+    try:
         return self.__dict__.get(self.__name__).__repr__()
+    except AttributeError:
+        return "<module>"
 
-
-module_type = type(
+module = type(
     "module",
-    (ReplacementModuleType, ModuleType),
+    (ModuleType_,),
     {
-        "__module__": ModuleValue(0),
-        # "__all__": [],
+        "__repr__": __repr__,
+        "__spec__": original_module.__spec__,
+        "__path__": original_module.__path__,
+        "__annotations__": original_module.__annotations__,
+        "__doc__": original_module.__doc__,
+        "__file__": original_module.__file__,
+        "__package__": original_module.__package__,
+        "__original_module__": original_module,
+        "__class__": ModuleType_,
+        "__all__": original_module.__all__,
+        "__call__": staticmethod_(utcnow.rfc3339_timestamp),
         **{
             attr: staticmethod_(getattr(utcnow, attr))
             for attr in dir(utcnow)
@@ -1189,44 +916,50 @@ module_type = type(
         },
     },
 )
+module_ = type("module", (module,), {})(original_module.__name__, original_module.__doc__)
+"""
 
-module_ = module_type(original_module.__name__, original_module.__doc__)
-# module_.__all__ = [
-#     "__version__",
-#     "__version_info__",
-#     "__author__",
-#     "__email__",
-#     "rfc3339_timestamp",
-#     "as_datetime",
-#     "as_unixtime",
-#     "as_protobuf",
-#     "as_date_string",
-#     "today",
-#     "timediff",
-#     "utcnow",
-#     "now",
-# ]
-
-module_.__dict__.update(
-    {
-        **{k: v for k, v in original_module.__dict__.items() if k in module_.__all__},
-        "__str__": original_module.__str__,
-        "__repr__": original_module.__repr__,
+    original_module = sys.modules[__name__]  # noqa
+    code_object = compile(code, "<string>", "exec")
+    globals_: Dict[str, Any] = {
+        "ModuleType_": ModuleType,
+        "staticmethod_": staticmethod_,
+        "utcnow": utcnow,
+        "FunctionType": FunctionType,
+        "original_module": original_module,
+        "cast": cast,
+        "__builtins__": {
+            "type": type,
+            "print": print,
+            "globals": globals,
+            "__build_class__": __build_class__,
+            "dir": dir,
+            "any": any,
+            "callable": callable,
+            "getattr": getattr,
+            "isinstance": isinstance,
+        },
     }
-)
+    locals_: Dict[str, Any] = {}
+    exec(code_object, globals_, locals_)
+    module_ = cast(ModuleType, locals_["module_"])
+    module_.__dict__.update(
+        {
+            **{k: v for k, v in original_module.__dict__.items() if k in module_.__all__},
+            "__str__": original_module.__str__,
+            "__repr__": original_module.__repr__,
+        }
+    )
+    module_.__spec__ = original_module.__spec__
+    module_.__path__ = original_module.__path__
+    module_.__annotations__ = original_module.__annotations__
+    module_.__doc__ = original_module.__doc__
+    module_.__file__ = original_module.__file__
+    module_.__name__ = original_module.__name__
+    module_.__package__ = original_module.__package__
 
-module_.__spec__ = original_module.__spec__
-module_.__path__ = original_module.__path__
-module_.__annotations__ = original_module.__annotations__
-module_.__cached__ = original_module.__cached__
-module_.__doc__ = original_module.__doc__
-module_.__file__ = original_module.__file__
-module_.__name__ = original_module.__name__
-module_.__package__ = original_module.__package__
+    if sys.modules[__name__] is original_module:
+        sys.modules[__name__] = module_
 
-sys.modules[__name__] = module_
-
-# module_.__dict__["__str__"] = original_module.__str__
-# module_.__dict__["__repr__"] = original_module.__repr__
-#
-# del sys
+del sys
+del annotations

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -51,7 +51,11 @@ at this date.
 
 See also:
 ``utcnow.as_date_string(value, tz)``
-    Transforms the input value to a string representing a date (YYYY-mm-dd) without timespec or timezone.
+    Transforms the input value to a string representing a date (YYYY-mm-dd) without timespec or indicated timezone.
+    An optional ``tz`` argument can be used to return the date in the specific timezone.
+``utcnow.today(tz)``
+    Returns a string representing today's date (YYYY-mm-dd) without timespec or indicated timezone.
+    An optional ``tz`` argument can be used to return today's date in the specific timezone.
 ``utcnow.timediff(begin, end, unit)``
     Calculate the time difference between two timestamps.
 """

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -70,7 +70,7 @@ if __name__ not in sys.modules or not getattr(sys.modules[__name__], "__original
     from decimal import Decimal
     from numbers import Real
     from types import FunctionType, ModuleType
-    from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union, cast
+    from typing import Any, Callable, Dict, Optional, Tuple, Type, TypeVar, Union, cast
 
     from .__version_data__ import __version__, __version_info__
     from .protobuf import TimestampProtobufMessage
@@ -458,12 +458,9 @@ if __name__ not in sys.modules or not getattr(sys.modules[__name__], "__original
             return datetime_.datetime.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
 
     class utcnow_(_baseclass):
-        __instance: Optional[utcnow_] = None
         now = type("now", (now_,), {})()
 
         def __new__(cls: Type[UT], *args: Any) -> UT:
-            if cls.__instance is not None:
-                return cast(UT, cls.__instance)
             result = object.__new__(cls, *args)
 
             for attr in dir(cls):

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -1,4 +1,5 @@
-"""
+"""utcnow: A library for formatting timestamps as RFC3339
+
 Timestamps as RFC 3339 (Date & Time on the Internet) formatted strings with conversion functionality from other
 timestamp formats or for timestamps on other timezones. Additionally converts timestamps from datetime objets
 and other common date utilities.
@@ -18,7 +19,6 @@ modifier: An optional modifier to be added to the Unix timestamp of the value. D
     Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
 
 Examples:
-
     A few examples of transforming an arbitrary timestamp value to a RFC3339 timestamp string.
 
     >>> import utcnow
@@ -48,6 +48,12 @@ followed by the timezone identifier for UTC: "Z".
 The library is specified to return timestamps with 6 fractional second digits, which means timestamps down to the
 microsecond level. Having a six-digit fraction of a second is currently the most common way that timestamps are shown
 at this date.
+
+See also:
+``utcnow.as_date_string(value, tz)``
+    Transforms the input value to a string representing a date (YYYY-mm-dd) without timespec or timezone.
+``utcnow.timediff(begin, end, unit)``
+    Calculate the time difference between two timestamps.
 """
 
 from __future__ import annotations
@@ -623,16 +629,16 @@ class utcnow_(_baseclass):
             ValueError: If an unknown unit is specified.
 
         Examples:
-            >>> from utcnow import timediff
-            >>> timediff("2022-01-01 00:00:00", "2022-01-01 00:00:10")
+            >>> import utcnow
+            >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-01 00:00:10")
             10.0
-            >>> timediff("2022-01-01 00:00:00", "2022-01-01 00:01:00", unit="minutes")
+            >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-01 00:01:00", unit="minutes")
             1.0
-            >>> timediff("2022-01-01 00:00:00", "2022-01-02 00:00:00", unit="days")
+            >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-02 00:00:00", unit="days")
             1.0
-            >>> timediff("2022-01-01T00:00:00.000000Z", "2022-01-02T06:00:00.000000Z", unit="days")
+            >>> utcnow.timediff("2022-01-01T00:00:00.000000Z", "2022-01-02T06:00:00.000000Z", unit="days")
             1.25
-            >>> timediff(0, 7200, unit="hours")
+            >>> utcnow.timediff(0, 7200, unit="hours")
             2.0
         """
         delta = _timestamp_to_datetime(end) - _timestamp_to_datetime(begin)

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -448,13 +448,12 @@ if __name__ not in sys.modules or not getattr(sys.modules[__name__], "__original
         @functools.wraps(func)
         def _wrapper(*a: Any, **kw: Any) -> Any:
             warnings.warn(
-                f"Using the '{deprecated_func_name}()' function alias is deprecated. Use the 'utcnow.{func.__name__}()' function instead.",
+                f"Using the '{deprecated_func_name}()' function alias is deprecated. Use the 'utcnow.{getattr(func, '__name__') if getattr(func, '__name__', None) else func.__func__.__name__}()' function instead.",
                 DeprecationWarning,
             )
-            print(
-                f"Using the '{deprecated_func_name}()' function alias is deprecated. Use the 'utcnow.{func.__name__}()' function instead."
-            )
 
+            if isinstance(func, staticmethod):
+                return func.__func__(*a, **kw)
             return func(*a, **kw)
 
         return cast(CT, staticmethod(_wrapper))

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -66,6 +66,7 @@ if __name__ not in sys.modules or not getattr(sys.modules[__name__], "__original
     import re
     import sys
     import time as time_
+    import warnings
     from datetime import datetime, timedelta, timezone, tzinfo
     from decimal import Decimal
     from numbers import Real
@@ -443,6 +444,21 @@ if __name__ not in sys.modules or not getattr(sys.modules[__name__], "__original
                 _transform_value(value) if not modifier else _transform_value(_timestamp_to_unixtime(value) + modifier)
             )
 
+    def _deprecation_decorator(func: CT, deprecated_func_name: str) -> CT:
+        @functools.wraps(func)
+        def _wrapper(*a: Any, **kw: Any) -> Any:
+            warnings.warn(
+                f"Using the '{deprecated_func_name}()' function alias is deprecated. Use the 'utcnow.{func.__name__}()' function instead.",
+                DeprecationWarning,
+            )
+            print(
+                f"Using the '{deprecated_func_name}()' function alias is deprecated. Use the 'utcnow.{func.__name__}()' function instead."
+            )
+
+            return func(*a, **kw)
+
+        return cast(CT, staticmethod(_wrapper))
+
     NT = TypeVar("NT", bound="now_")
     UT = TypeVar("UT", bound="utcnow_")
 
@@ -470,13 +486,12 @@ if __name__ not in sys.modules or not getattr(sys.modules[__name__], "__original
                         not callable(getattr(result, attr)),
                         not isinstance(getattr(result, attr), FunctionType),
                         "." not in getattr(getattr(result, attr), "__qualname__", "."),
-                        getattr(getattr(result, attr), "__qualname__", ".").rsplit(".", 1)[-1] != attr,
                     )
                 ):
                     continue
 
                 func = getattr(result, attr)
-                func.__qualname__ = attr
+                func.__qualname__ = getattr(getattr(result, attr), "__qualname__", ".").rsplit(".", 1)[-1]
 
             return result
 
@@ -783,111 +798,112 @@ if __name__ not in sys.modules or not getattr(sys.modules[__name__], "__original
             return utcnow_.as_date_string(tz=tz)
 
         as_string = rfc3339_timestamp
-        as_str = rfc3339_timestamp
-        as_rfc3339 = rfc3339_timestamp
-        to_string = rfc3339_timestamp
-        to_str = rfc3339_timestamp
-        to_rfc3339 = rfc3339_timestamp
-        get_string = rfc3339_timestamp
-        get_str = rfc3339_timestamp
-        get_rfc3339 = rfc3339_timestamp
         get = rfc3339_timestamp
-        string = rfc3339_timestamp
-        rfc3339 = rfc3339_timestamp
-        timestamp_rfc3339 = rfc3339_timestamp
-        ts_rfc3339 = rfc3339_timestamp
-        rfc3339_ts = rfc3339_timestamp
-        utcnow_rfc3339 = rfc3339_timestamp
-        rfc3339_utcnow = rfc3339_timestamp
-        now_rfc3339 = rfc3339_timestamp
-        rfc3339_now = rfc3339_timestamp
-        get_now = rfc3339_timestamp
 
-        as_date = as_datetime
-        as_dt = as_datetime
-        to_datetime = as_datetime
-        to_date = as_datetime
-        to_dt = as_datetime
-        get_datetime = as_datetime
-        get_date = as_datetime
-        get_dt = as_datetime
-        date = as_datetime
-        dt = as_datetime
+        as_str = _deprecation_decorator(rfc3339_timestamp, "utcnow.as_str")
+        as_rfc3339 = _deprecation_decorator(rfc3339_timestamp, "utcnow.as_rfc3339")
+        to_string = _deprecation_decorator(rfc3339_timestamp, "utcnow.to_string")
+        to_str = _deprecation_decorator(rfc3339_timestamp, "utcnow.to_str")
+        to_rfc3339 = _deprecation_decorator(rfc3339_timestamp, "utcnow.to_rfc3339")
+        get_string = _deprecation_decorator(rfc3339_timestamp, "utcnow.get_string")
+        get_str = _deprecation_decorator(rfc3339_timestamp, "utcnow.get_str")
+        get_rfc3339 = _deprecation_decorator(rfc3339_timestamp, "utcnow.get_rfc3339")
+        string = _deprecation_decorator(rfc3339_timestamp, "utcnow.string")
+        rfc3339 = _deprecation_decorator(rfc3339_timestamp, "utcnow.rfc3339")
+        timestamp_rfc3339 = _deprecation_decorator(rfc3339_timestamp, "utcnow.timestamp_rfc3339")
+        ts_rfc3339 = _deprecation_decorator(rfc3339_timestamp, "utcnow.ts_rfc3339")
+        rfc3339_ts = _deprecation_decorator(rfc3339_timestamp, "utcnow.rfc3339_ts")
+        utcnow_rfc3339 = _deprecation_decorator(rfc3339_timestamp, "utcnow.utcnow_rfc3339")
+        rfc3339_utcnow = _deprecation_decorator(rfc3339_timestamp, "utcnow.rfc3339_utcnow")
+        now_rfc3339 = _deprecation_decorator(rfc3339_timestamp, "utcnow.now_rfc3339")
+        rfc3339_now = _deprecation_decorator(rfc3339_timestamp, "utcnow.rfc3339_now")
+        get_now = _deprecation_decorator(rfc3339_timestamp, "utcnow.get_now")
 
-        as_unix = as_unixtime
-        as_time = as_unixtime
-        as_timestamp = as_unixtime
-        as_ut = as_unixtime
-        as_ts = as_unixtime
-        as_float = as_unixtime
-        to_unixtime = as_unixtime
-        to_unix = as_unixtime
-        to_time = as_unixtime
-        to_timestamp = as_unixtime
-        to_ut = as_unixtime
-        to_ts = as_unixtime
-        to_float = as_unixtime
-        get_unixtime = as_unixtime
-        get_unix = as_unixtime
-        get_time = as_unixtime
-        get_timestamp = as_unixtime
-        get_ut = as_unixtime
-        get_ts = as_unixtime
-        get_float = as_unixtime
-        unixtime = as_unixtime
-        unix = as_unixtime
-        time = as_unixtime
-        timestamp = as_unixtime
-        ut = as_unixtime
-        ts = as_unixtime
+        as_date = _deprecation_decorator(as_datetime, "utcnow.as_date")
+        as_dt = _deprecation_decorator(as_datetime, "utcnow.as_dt")
+        to_datetime = _deprecation_decorator(as_datetime, "utcnow.to_datetime")
+        to_date = _deprecation_decorator(as_datetime, "utcnow.to_date")
+        to_dt = _deprecation_decorator(as_datetime, "utcnow.to_dt")
+        get_datetime = _deprecation_decorator(as_datetime, "utcnow.get_datetime")
+        get_date = _deprecation_decorator(as_datetime, "utcnow.get_date")
+        get_dt = _deprecation_decorator(as_datetime, "utcnow.get_dt")
+        date = _deprecation_decorator(as_datetime, "utcnow.date")
+        dt = _deprecation_decorator(as_datetime, "utcnow.dt")
 
-        as_proto = as_protobuf
-        as_protobuf_timestamp = as_protobuf
-        as_proto_timestamp = as_protobuf
-        as_pb = as_protobuf
-        to_protobuf = as_protobuf
-        to_proto = as_protobuf
-        to_protobuf_timestamp = as_protobuf
-        to_proto_timestamp = as_protobuf
-        to_pb = as_protobuf
-        get_protobuf = as_protobuf
-        get_proto = as_protobuf
-        get_protobuf_timestamp = as_protobuf
-        get_proto_timestamp = as_protobuf
-        get_pb = as_protobuf
-        proto = as_protobuf
-        protobuf_timestamp = as_protobuf
-        proto_timestamp = as_protobuf
-        pb = as_protobuf
+        as_unix = _deprecation_decorator(as_unixtime, "utcnow.as_unix")
+        as_time = _deprecation_decorator(as_unixtime, "utcnow.as_time")
+        as_timestamp = _deprecation_decorator(as_unixtime, "utcnow.as_timestamp")
+        as_ut = _deprecation_decorator(as_unixtime, "utcnow.as_ut")
+        as_ts = _deprecation_decorator(as_unixtime, "utcnow.as_ts")
+        as_float = _deprecation_decorator(as_unixtime, "utcnow.as_float")
+        to_unixtime = _deprecation_decorator(as_unixtime, "utcnow.to_unixtime")
+        to_unix = _deprecation_decorator(as_unixtime, "utcnow.to_unix")
+        to_time = _deprecation_decorator(as_unixtime, "utcnow.to_time")
+        to_timestamp = _deprecation_decorator(as_unixtime, "utcnow.to_timestamp")
+        to_ut = _deprecation_decorator(as_unixtime, "utcnow.to_ut")
+        to_ts = _deprecation_decorator(as_unixtime, "utcnow.to_ts")
+        to_float = _deprecation_decorator(as_unixtime, "utcnow.to_float")
+        get_unixtime = _deprecation_decorator(as_unixtime, "utcnow.get_unixtime")
+        get_unix = _deprecation_decorator(as_unixtime, "utcnow.get_unix")
+        get_time = _deprecation_decorator(as_unixtime, "utcnow.get_time")
+        get_timestamp = _deprecation_decorator(as_unixtime, "utcnow.get_timestamp")
+        get_ut = _deprecation_decorator(as_unixtime, "utcnow.get_ut")
+        get_ts = _deprecation_decorator(as_unixtime, "utcnow.get_ts")
+        get_float = _deprecation_decorator(as_unixtime, "utcnow.get_float")
+        unixtime = _deprecation_decorator(as_unixtime, "utcnow.unixtime")
+        unix = _deprecation_decorator(as_unixtime, "utcnow.unix")
+        time = _deprecation_decorator(as_unixtime, "utcnow.time")
+        timestamp = _deprecation_decorator(as_unixtime, "utcnow.timestamp")
+        ut = _deprecation_decorator(as_unixtime, "utcnow.ut")
+        ts = _deprecation_decorator(as_unixtime, "utcnow.ts")
 
-        time_diff = timediff
-        diff = timediff
-        timedelta = timediff
-        delta = timediff
+        as_proto = _deprecation_decorator(as_protobuf, "utcnow.as_proto")
+        as_protobuf_timestamp = _deprecation_decorator(as_protobuf, "utcnow.as_protobuf_timestamp")
+        as_proto_timestamp = _deprecation_decorator(as_protobuf, "utcnow.as_proto_timestamp")
+        as_pb = _deprecation_decorator(as_protobuf, "utcnow.as_pb")
+        to_protobuf = _deprecation_decorator(as_protobuf, "utcnow.to_protobuf")
+        to_proto = _deprecation_decorator(as_protobuf, "utcnow.to_proto")
+        to_protobuf_timestamp = _deprecation_decorator(as_protobuf, "utcnow.to_protobuf_timestamp")
+        to_proto_timestamp = _deprecation_decorator(as_protobuf, "utcnow.to_proto_timestamp")
+        to_pb = _deprecation_decorator(as_protobuf, "utcnow.to_pb")
+        get_protobuf = _deprecation_decorator(as_protobuf, "utcnow.get_protobuf")
+        get_proto = _deprecation_decorator(as_protobuf, "utcnow.get_proto")
+        get_protobuf_timestamp = _deprecation_decorator(as_protobuf, "utcnow.get_protobuf_timestamp")
+        get_proto_timestamp = _deprecation_decorator(as_protobuf, "utcnow.get_proto_timestamp")
+        get_pb = _deprecation_decorator(as_protobuf, "utcnow.get_pb")
+        proto = _deprecation_decorator(as_protobuf, "utcnow.proto")
+        protobuf_timestamp = _deprecation_decorator(as_protobuf, "utcnow.protobuf_timestamp")
+        proto_timestamp = _deprecation_decorator(as_protobuf, "utcnow.proto_timestamp")
+        pb = _deprecation_decorator(as_protobuf, "utcnow.pb")
 
-        as_datestring = as_date_string
-        as_date_str = as_date_string
-        as_datestr = as_date_string
-        to_date_string = as_date_string
-        to_datestring = as_date_string
-        to_date_str = as_date_string
-        to_datestr = as_date_string
-        get_date_string = as_date_string
-        get_datestring = as_date_string
-        get_datestr = as_date_string
-        get_date_string = as_date_string
-        date_string = as_date_string
-        datestring = as_date_string
-        date_str = as_date_string
-        datestr = as_date_string
+        time_diff = _deprecation_decorator(timediff, "utcnow.time_diff")
+        diff = _deprecation_decorator(timediff, "utcnow.diff")
+        timedelta = _deprecation_decorator(timediff, "utcnow.timedelta")
+        delta = _deprecation_decorator(timediff, "utcnow.delta")
 
-        get_today = today
-        get_today_date = today
-        get_todays_date = today
-        get_date_today = today
-        date_today = as_date_string
-        today_date = today
-        todays_date = today
+        as_datestring = _deprecation_decorator(as_date_string, "utcnow.as_datestring")
+        as_date_str = _deprecation_decorator(as_date_string, "utcnow.as_date_str")
+        as_datestr = _deprecation_decorator(as_date_string, "utcnow.as_datestr")
+        to_date_string = _deprecation_decorator(as_date_string, "utcnow.to_date_string")
+        to_datestring = _deprecation_decorator(as_date_string, "utcnow.to_datestring")
+        to_date_str = _deprecation_decorator(as_date_string, "utcnow.to_date_str")
+        to_datestr = _deprecation_decorator(as_date_string, "utcnow.to_datestr")
+        get_date_string = _deprecation_decorator(as_date_string, "utcnow.get_date_string")
+        get_datestring = _deprecation_decorator(as_date_string, "utcnow.get_datestring")
+        get_datestr = _deprecation_decorator(as_date_string, "utcnow.get_datestr")
+        get_date_string = _deprecation_decorator(as_date_string, "utcnow.get_date_string")
+        date_string = _deprecation_decorator(as_date_string, "utcnow.date_string")
+        datestring = _deprecation_decorator(as_date_string, "utcnow.datestring")
+        date_str = _deprecation_decorator(as_date_string, "utcnow.date_str")
+        datestr = _deprecation_decorator(as_date_string, "utcnow.datestr")
+
+        get_today = _deprecation_decorator(today, "utcnow.get_today")
+        get_today_date = _deprecation_decorator(today, "utcnow.get_today_date")
+        get_todays_date = _deprecation_decorator(today, "utcnow.get_todays_date")
+        get_date_today = _deprecation_decorator(today, "utcnow.get_date_today")
+        date_today = _deprecation_decorator(as_date_string, "utcnow.date_today")
+        today_date = _deprecation_decorator(today, "utcnow.today_date")
+        todays_date = _deprecation_decorator(today, "utcnow.todays_date")
 
         def __str__(self) -> str:
             return self.rfc3339_timestamp()
@@ -902,9 +918,9 @@ if __name__ not in sys.modules or not getattr(sys.modules[__name__], "__original
         "utcnow",
         (utcnow_,),
         {
-            "str": staticmethod_(utcnow_.rfc3339_timestamp),
-            "datetime": staticmethod_(utcnow_.as_datetime),
-            "protobuf": staticmethod_(utcnow_.as_protobuf),
+            "str": _deprecation_decorator(utcnow_.rfc3339_timestamp, "utcnow.str"),
+            "datetime": _deprecation_decorator(utcnow_.as_datetime, "utcnow.datetime"),
+            "protobuf": _deprecation_decorator(utcnow_.as_protobuf, "utcnow.protobuf"),
         },
     )
     utcnow = now = utcnow_type()

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -567,7 +567,7 @@ if __name__ not in sys.modules or not getattr(sys.modules[__name__], "__original
             return (
                 _timestamp_to_datetime(value)
                 if not modifier
-                else datetime_.datetime.now(UTC) + timedelta(seconds=modifier)
+                else _timestamp_to_datetime(value) + timedelta(seconds=modifier)
             )
 
         @staticmethod

--- a/utcnow/__init__.py
+++ b/utcnow/__init__.py
@@ -1,11 +1,11 @@
 """Package for formatting arbitrary timestamps as strict RFC 3339.
 
 Timestamps as RFC 3339 (Date & Time on the Internet) formatted strings with conversion functionality from other
-timestamp formats or for timestamps on other timezones. Additionally converts timestamps from datetime objets
+timestamp formats or for timestamps on other timezones. Additionally converts timestamps from datetime objects
 and other common date utilities.
 
 ``utcnow.rfc3339_timestamp(value, modifier)``
-    Transforms the input value to a timestamp string in RFC3339 format.
+    Transforms the input value to a timestamp string in RFC 3339 format.
 ``utcnow.as_datetime(value, modifier)``
     Transforms the input value to a datetime object.
 ``utcnow.as_unixtime(value, modifier)``
@@ -19,7 +19,7 @@ modifier: An optional modifier to be added to the Unix timestamp of the value. D
     Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
 
 Examples:
-    A few examples of transforming an arbitrary timestamp value to a RFC3339 timestamp string.
+    A few examples of transforming an arbitrary timestamp value to a RFC 3339 timestamp string.
 
     >>> import utcnow
     >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00")
@@ -235,13 +235,13 @@ if __name__ not in sys.modules or not getattr(sys.modules[__name__], "__original
 
     @functools.lru_cache(maxsize=128, typed=True)
     def _transform_value(value: Union[str, datetime, object, int, float, Decimal, Real]) -> str:
-        """Transforms the input value to a timestamp string in RFC3339 format.
+        """Transforms the input value to a timestamp string in RFC 3339 format.
 
         Args:
             value: A value representing a timestamp in any of the allowed input formats.
 
         Returns:
-            The transformed value as a string in RFC3339 format.
+            The transformed value as a string in RFC 3339 format.
         """
         str_value: str
         try:
@@ -420,7 +420,7 @@ if __name__ not in sys.modules or not getattr(sys.modules[__name__], "__original
             value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
             modifier: Optional[Union[str, int, float]] = 0,
         ) -> str:
-            """Transforms the input value to a timestamp string in RFC3339 format.
+            """Transforms the input value to a timestamp string in RFC 3339 format.
 
             Args:
                 value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
@@ -429,7 +429,7 @@ if __name__ not in sys.modules or not getattr(sys.modules[__name__], "__original
                     Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
 
             Returns:
-                The transformed value as a string in RFC3339 format.
+                The transformed value as a string in RFC 3339 format.
 
             Raises:
                 ValueError: If the input value does not match allowed input formats.
@@ -505,7 +505,7 @@ if __name__ not in sys.modules or not getattr(sys.modules[__name__], "__original
             value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
             modifier: Optional[Union[str, int, float]] = 0,
         ) -> str:
-            """Transforms the input value to a timestamp string in RFC3339 format.
+            """Transforms the input value to a timestamp string in RFC 3339 format.
 
             Args:
                 value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
@@ -514,7 +514,7 @@ if __name__ not in sys.modules or not getattr(sys.modules[__name__], "__original
                     Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
 
             Returns:
-                The transformed value as a string in RFC3339 format.
+                The transformed value as a string in RFC 3339 format.
 
             Raises:
                 ValueError: If the input value does not match allowed input formats.

--- a/utcnow/__init__.pyi
+++ b/utcnow/__init__.pyi
@@ -4,8 +4,7 @@ import functools
 from datetime import datetime, tzinfo
 from decimal import Decimal
 from numbers import Real
-from types import EllipsisType, FunctionType, MethodType, MethodWrapperType, WrapperDescriptorType
-from typing import Any, Generic, Optional, Type, TypeVar, Union, cast
+from typing import Any, Generic, Optional, Type, TypeVar, Union
 
 from utcnow.protobuf import TimestampProtobufMessage
 

--- a/utcnow/__init__.pyi
+++ b/utcnow/__init__.pyi
@@ -1,0 +1,1185 @@
+import functools
+from datetime import datetime, tzinfo
+from decimal import Decimal
+from numbers import Real
+from typing import Any, Optional, Union
+
+from utcnow.protobuf import TimestampProtobufMessage
+
+from .__version_data__ import __version__, __version_info__
+
+__author__: str = ...
+__email__: str = ...
+
+NOW: object = ...
+TODAY: object = ...
+
+def rfc3339_timestamp(
+    value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+    modifier: Optional[Union[str, int, float]] = 0,
+) -> str:
+    """Transforms the input value to a timestamp string in RFC3339 format.
+
+    Args:
+        value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+        modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+            Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+            Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+    Returns:
+        The transformed value as a string in RFC3339 format.
+
+    Raises:
+        ValueError: If the input value does not match allowed input formats.
+
+    Examples:
+        >>> import utcnow
+        >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00")
+        "2023-09-07T02:18:00.000000Z"
+        >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00", "+7d")
+        "2023-09-14T02:18:00.000000Z"
+        >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00+02:00")
+        "2023-09-07T00:18:00.000000Z"
+        >>> utcnow.rfc3339_timestamp(1693005993.285967)
+        "2023-08-25T23:26:33.285967Z"
+        >>> from datetime import datetime, timezone, timedelta
+        >>> tz = timezone(timedelta(hours=2, minutes=0))
+        >>> dt = datetime(2023, 4, 30, 8, 0, 0, tzinfo=tz)
+        >>> utcnow.rfc3339_timestamp(dt)
+        "2023-04-30T06:00:00.000000Z"
+    """
+
+def as_datetime(
+    value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+    modifier: Optional[Union[str, int, float]] = 0,
+) -> datetime:
+    """Transforms the input value to a datetime object.
+
+    Args:
+        value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+        modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+            Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+            Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+    Returns:
+        The transformed value as a datetime object.
+
+    Raises:
+        ValueError: If the input value does not match allowed input formats.
+
+    Examples:
+        >>> import utcnow
+        >>> utcnow.as_datetime("2023-08-01 12:10:59.123456+02:00")
+        datetime.datetime(2023, 8, 1, 10, 10, 59, 123456, tzinfo=datetime.timezone.utc)
+    """
+
+def as_unixtime(
+    value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+    modifier: Optional[Union[str, int, float]] = 0,
+) -> float:
+    """Transforms the input value to a float value representing a timestamp as unixtime.
+
+    Args:
+        value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+        modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+            Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+            Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+    Returns:
+        The transformed value in unixtime (float).
+
+    Raises:
+        ValueError: If the input value does not match allowed input formats.
+
+    Examples:
+        >>> import utcnow
+        >>> utcnow.as_unixtime("1970-01-01T00:00:00.000000Z")
+        0.0
+        >>> utcnow.as_unixtime("1970-01-01T00:00:00.000000Z", "+24h")
+        86400.0
+        >>> utcnow.as_unixtime("2022-01-01 00:00:00.123456+00:00")
+        1640995200.123456
+    """
+
+def as_protobuf(
+    value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+    modifier: Optional[Union[str, int, float]] = 0,
+) -> TimestampProtobufMessage:
+    """Transforms the input value to a google.protobuf.Timestamp protobuf message.
+
+    Args:
+        value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+        modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+            Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+            Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+    Returns:
+        The transformed value as a google.protobuf.Timestamp message.
+
+    Raises:
+        ValueError: If the input value does not match allowed input formats.
+
+    Examples:
+        >>> import utcnow
+        >>> utcnow.as_protobuf("2022-01-01 00:00:00.123456+00:00")
+        seconds: 1640995200
+        nanos: 123456000
+        >>> utcnow.as_protobuf(1234567890.05, modifier=-0.1)
+        seconds: 1234567889
+        nanos: 950000000
+    """
+
+def timediff(
+    begin: Union[str, datetime, object, int, float, Decimal, Real],
+    end: Union[str, datetime, object, int, float, Decimal, Real],
+    unit: str = "seconds",
+) -> float:
+    """Calculate the time difference between two timestamps.
+
+    Args:
+        begin: The beginning timestamp. Can be a string, datetime object, or a numeric unixtime value.
+        end: The ending timestamp. Can be a string, datetime object, or a numeric unixtime value.
+        unit: The unit of time to return the difference in. Defaults to "seconds".
+
+    Returns:
+        The time difference between the two timestamps in the specified unit.
+
+    Raises:
+        ValueError: If an unknown unit is specified.
+
+    Examples:
+        >>> import utcnow
+        >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-01 00:00:10")
+        10.0
+        >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-01 00:01:00", unit="minutes")
+        1.0
+        >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-02 00:00:00", unit="days")
+        1.0
+        >>> utcnow.timediff("2022-01-01T00:00:00.000000Z", "2022-01-02T06:00:00.000000Z", unit="days")
+        1.25
+        >>> utcnow.timediff(0, 7200, unit="hours")
+        2.0
+    """
+
+def as_date_string(
+    value: Union[str, datetime, object, int, float, Decimal, Real] = TODAY,
+    tz: Optional[Union[str, tzinfo]] = None,
+) -> str:
+    """Transforms the input value to a string representing a date (YYYY-mm-dd) without timespec or timezone.
+
+    Args:
+        value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+        tz: An optional timezone for which the date is represented related to the input value.
+            If not specified, UTC timezone will be applied.
+
+    Returns:
+        A string representing a date (YYYY-mm-dd) without timespec or timezone.
+
+    Raises:
+        ValueError: If the input value does not match allowed input formats.
+
+    Examples:
+        >>> import utcnow
+        >>> utcnow.as_date_string("2023-09-07 02:18:00")
+        "2023-09-07"
+        >>> utcnow.as_date_string("2020-01-01T00:00:00.000000Z")
+        "2020-01-01"
+        >>> utcnow.as_date_string("2020-01-01T00:00:00.000000+02:00")
+        "2019-12-31"
+        >>> utcnow.as_date_string("2020-01-01T00:00:00.000000+02:00", "+02:00")
+        "2020-01-01"
+        >>> utcnow.as_date_string(1234567890.123456)
+        "2009-02-13"
+        >>> utcnow.as_date_string(0)
+        "1970-01-01"
+        >>> utcnow.as_date_string()
+        "2023-09-07"  # current date
+    """
+
+def today(
+    tz: Optional[Union[str, tzinfo]] = None,
+) -> str:
+    """Returns a string representing today's date (YYYY-mm-dd) without timespec or timezone.
+
+    Args:
+        tz: An optional timezone value that is used to return today's date in the specific timezone.
+            If not specified, UTC timezone will be applied. Note that the timezone value will not be
+            represented in the returned value, only the current date (YYYY-mm-dd) in the specified timezone.
+
+    Returns:
+        A string representing today's date (YYYY-mm-dd) without timespec or timezone.
+
+    Raises:
+        ValueError: If the input value does not match allowed input formats.
+
+    Examples:
+        >>> import pytz
+        >>> import utcnow
+        >>> utcnow.rfc3339_timestamp()
+        "2023-09-07T23:31:25.134196Z"  # current time
+        >>> utcnow.today()
+        "2023-09-07"  # current date
+        >>> timezone = pytz.timezone("Europe/Stockholm")  # UTC+02:00
+        >>> utcnow.today(tz=timezone)
+        "2023-09-08"  # current date in Europe/Stockholm timezone
+        >>> utcnow.today(tz="+01:00")
+        "2023-09-08"  # current date in a timezone with UTC offset +01:00
+    """
+
+@functools.lru_cache(maxsize=128, typed=False)
+def _is_numeric(value: str) -> bool:
+    """
+    Determines if a string represents a numeric value. A numeric values can optionally start with "-" (negative),
+    optionally have a leading "." (decimal point) before any digit or can optionally end with "." (decimal point),
+    meaning there is no decimal fragment present in the number.
+
+    Args:
+        value: A string to check for numeric representation.
+
+    Returns:
+        True if the string represents a numeric value, False otherwise.
+    """
+
+@functools.lru_cache(maxsize=128)
+def _timestamp_to_datetime(value: str) -> datetime:
+    """Transforms the input value to a datetime object.
+
+    Args:
+        value: A value representing a timestamp in any of the allowed input formats.
+
+    Returns:
+        The transformed value as a datetime object.
+    """
+
+@functools.lru_cache(maxsize=128, typed=True)
+def _transform_value(value: Union[str, datetime, object, int, float, Decimal, Real]) -> str:
+    """Transforms the input value to a timestamp string in RFC3339 format.
+
+    Args:
+        value: A value representing a timestamp in any of the allowed input formats.
+
+    Returns:
+        The transformed value as a string in RFC3339 format.
+    """
+
+class utcnow(str):
+    def __repr__(self) -> str: ...
+    def __str__(self) -> str: ...
+    def __new__(  # type: ignore
+        cls,
+        value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> str:
+        """Transforms the input value to a timestamp string in RFC3339 format.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+        Returns:
+            The transformed value as a string in RFC3339 format.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+        """
+    def __call__(
+        self,
+        value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> str:
+        """Transforms the input value to a timestamp string in RFC3339 format.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+        Returns:
+            The transformed value as a string in RFC3339 format.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+        """
+    @staticmethod
+    def rfc3339_timestamp(
+        value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> str:
+        """Transforms the input value to a timestamp string in RFC3339 format.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+        Returns:
+            The transformed value as a string in RFC3339 format.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+
+        Examples:
+            >>> import utcnow
+            >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00")
+            "2023-09-07T02:18:00.000000Z"
+            >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00", "+7d")
+            "2023-09-14T02:18:00.000000Z"
+            >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00+02:00")
+            "2023-09-07T00:18:00.000000Z"
+            >>> utcnow.rfc3339_timestamp(1693005993.285967)
+            "2023-08-25T23:26:33.285967Z"
+            >>> from datetime import datetime, timezone, timedelta
+            >>> tz = timezone(timedelta(hours=2, minutes=0))
+            >>> dt = datetime(2023, 4, 30, 8, 0, 0, tzinfo=tz)
+            >>> utcnow.rfc3339_timestamp(dt)
+            "2023-04-30T06:00:00.000000Z"
+        """
+    @staticmethod
+    def as_datetime(
+        value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> datetime:
+        """Transforms the input value to a datetime object.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+        Returns:
+            The transformed value as a datetime object.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+
+        Examples:
+            >>> import utcnow
+            >>> utcnow.as_datetime("2023-08-01 12:10:59.123456+02:00")
+            datetime.datetime(2023, 8, 1, 10, 10, 59, 123456, tzinfo=datetime.timezone.utc)
+        """
+    @staticmethod
+    def as_unixtime(
+        value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> float:
+        """Transforms the input value to a float value representing a timestamp as unixtime.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+        Returns:
+            The transformed value in unixtime (float).
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+
+        Examples:
+            >>> import utcnow
+            >>> utcnow.as_unixtime("1970-01-01T00:00:00.000000Z")
+            0.0
+            >>> utcnow.as_unixtime("1970-01-01T00:00:00.000000Z", "+24h")
+            86400.0
+            >>> utcnow.as_unixtime("2022-01-01 00:00:00.123456+00:00")
+            1640995200.123456
+        """
+    @staticmethod
+    def as_protobuf(
+        value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> TimestampProtobufMessage:
+        """Transforms the input value to a google.protobuf.Timestamp protobuf message.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+        Returns:
+            The transformed value as a google.protobuf.Timestamp message.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+
+        Examples:
+            >>> import utcnow
+            >>> utcnow.as_protobuf("2022-01-01 00:00:00.123456+00:00")
+            seconds: 1640995200
+            nanos: 123456000
+            >>> utcnow.as_protobuf(1234567890.05, modifier=-0.1)
+            seconds: 1234567889
+            nanos: 950000000
+        """
+    @staticmethod
+    def timediff(
+        begin: Union[str, datetime, object, int, float, Decimal, Real],
+        end: Union[str, datetime, object, int, float, Decimal, Real],
+        unit: str = "seconds",
+    ) -> float:
+        """Calculate the time difference between two timestamps.
+
+        Args:
+            begin: The beginning timestamp. Can be a string, datetime object, or a numeric unixtime value.
+            end: The ending timestamp. Can be a string, datetime object, or a numeric unixtime value.
+            unit: The unit of time to return the difference in. Defaults to "seconds".
+
+        Returns:
+            The time difference between the two timestamps in the specified unit.
+
+        Raises:
+            ValueError: If an unknown unit is specified.
+
+        Examples:
+            >>> import utcnow
+            >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-01 00:00:10")
+            10.0
+            >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-01 00:01:00", unit="minutes")
+            1.0
+            >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-02 00:00:00", unit="days")
+            1.0
+            >>> utcnow.timediff("2022-01-01T00:00:00.000000Z", "2022-01-02T06:00:00.000000Z", unit="days")
+            1.25
+            >>> utcnow.timediff(0, 7200, unit="hours")
+            2.0
+        """
+    @staticmethod
+    def as_date_string(
+        value: Union[str, datetime, object, int, float, Decimal, Real] = TODAY,
+        tz: Optional[Union[str, tzinfo]] = None,
+    ) -> str:
+        """Transforms the input value to a string representing a date (YYYY-mm-dd) without timespec or timezone.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            tz: An optional timezone for which the date is represented related to the input value.
+                If not specified, UTC timezone will be applied.
+
+        Returns:
+            A string representing a date (YYYY-mm-dd) without timespec or timezone.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+
+        Examples:
+            >>> import utcnow
+            >>> utcnow.as_date_string("2023-09-07 02:18:00")
+            "2023-09-07"
+            >>> utcnow.as_date_string("2020-01-01T00:00:00.000000Z")
+            "2020-01-01"
+            >>> utcnow.as_date_string("2020-01-01T00:00:00.000000+02:00")
+            "2019-12-31"
+            >>> utcnow.as_date_string("2020-01-01T00:00:00.000000+02:00", "+02:00")
+            "2020-01-01"
+            >>> utcnow.as_date_string(1234567890.123456)
+            "2009-02-13"
+            >>> utcnow.as_date_string(0)
+            "1970-01-01"
+            >>> utcnow.as_date_string()
+            "2023-09-07"  # current date
+        """
+    @staticmethod
+    def today(
+        tz: Optional[Union[str, tzinfo]] = None,
+    ) -> str:
+        """Returns a string representing today's date (YYYY-mm-dd) without timespec or timezone.
+
+        Args:
+            tz: An optional timezone value that is used to return today's date in the specific timezone.
+                If not specified, UTC timezone will be applied. Note that the timezone value will not be
+                represented in the returned value, only the current date (YYYY-mm-dd) in the specified timezone.
+
+        Returns:
+            A string representing today's date (YYYY-mm-dd) without timespec or timezone.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+
+        Examples:
+            >>> import pytz
+            >>> import utcnow
+            >>> utcnow.rfc3339_timestamp()
+            "2023-09-07T23:31:25.134196Z"  # current time
+            >>> utcnow.today()
+            "2023-09-07"  # current date
+            >>> timezone = pytz.timezone("Europe/Stockholm")  # UTC+02:00
+            >>> utcnow.today(tz=timezone)
+            "2023-09-08"  # current date in Europe/Stockholm timezone
+            >>> utcnow.today(tz="+01:00")
+            "2023-09-08"  # current date in a timezone with UTC offset +01:00
+        """
+    @staticmethod
+    def now(
+        value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> str:
+        """Transforms the input value to a timestamp string in RFC3339 format.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+        Returns:
+            The transformed value as a string in RFC3339 format.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+
+        Examples:
+            >>> import utcnow
+            >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00")
+            "2023-09-07T02:18:00.000000Z"
+            >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00", "+7d")
+            "2023-09-14T02:18:00.000000Z"
+            >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00+02:00")
+            "2023-09-07T00:18:00.000000Z"
+            >>> utcnow.rfc3339_timestamp(1693005993.285967)
+            "2023-08-25T23:26:33.285967Z"
+            >>> from datetime import datetime, timezone, timedelta
+            >>> tz = timezone(timedelta(hours=2, minutes=0))
+            >>> dt = datetime(2023, 4, 30, 8, 0, 0, tzinfo=tz)
+            >>> utcnow.rfc3339_timestamp(dt)
+            "2023-04-30T06:00:00.000000Z"
+        """
+    as_string = rfc3339_timestamp
+    as_str = rfc3339_timestamp
+    as_rfc3339 = rfc3339_timestamp
+    to_string = rfc3339_timestamp
+    to_str = rfc3339_timestamp
+    to_rfc3339 = rfc3339_timestamp
+    get_string = rfc3339_timestamp
+    get_str = rfc3339_timestamp
+    get_rfc3339 = rfc3339_timestamp
+    get = rfc3339_timestamp
+    string = rfc3339_timestamp
+    str = rfc3339_timestamp
+    rfc3339 = rfc3339_timestamp
+    timestamp_rfc3339 = rfc3339_timestamp
+    ts_rfc3339 = rfc3339_timestamp
+    rfc3339_ts = rfc3339_timestamp
+    utcnow_rfc3339 = rfc3339_timestamp
+    rfc3339_utcnow = rfc3339_timestamp
+    now_rfc3339 = rfc3339_timestamp
+    rfc3339_now = rfc3339_timestamp
+    get_now = rfc3339_timestamp
+
+    as_date = as_datetime
+    as_dt = as_datetime
+    to_datetime = as_datetime
+    to_date = as_datetime
+    to_dt = as_datetime
+    get_datetime = as_datetime
+    get_date = as_datetime
+    get_dt = as_datetime
+    datetime = as_datetime
+    date = as_datetime
+    dt = as_datetime
+
+    as_unix = as_unixtime
+    as_time = as_unixtime
+    as_timestamp = as_unixtime
+    as_ut = as_unixtime
+    as_ts = as_unixtime
+    as_float = as_unixtime
+    to_unixtime = as_unixtime
+    to_unix = as_unixtime
+    to_time = as_unixtime
+    to_timestamp = as_unixtime
+    to_ut = as_unixtime
+    to_ts = as_unixtime
+    to_float = as_unixtime
+    get_unixtime = as_unixtime
+    get_unix = as_unixtime
+    get_time = as_unixtime
+    get_timestamp = as_unixtime
+    get_ut = as_unixtime
+    get_ts = as_unixtime
+    get_float = as_unixtime
+    unixtime = as_unixtime
+    unix = as_unixtime
+    time = as_unixtime
+    timestamp = as_unixtime
+    ut = as_unixtime
+    ts = as_unixtime
+
+    as_proto = as_protobuf
+    as_protobuf_timestamp = as_protobuf
+    as_proto_timestamp = as_protobuf
+    as_pb = as_protobuf
+    to_protobuf = as_protobuf
+    to_proto = as_protobuf
+    to_protobuf_timestamp = as_protobuf
+    to_proto_timestamp = as_protobuf
+    to_pb = as_protobuf
+    get_protobuf = as_protobuf
+    get_proto = as_protobuf
+    get_protobuf_timestamp = as_protobuf
+    get_proto_timestamp = as_protobuf
+    get_pb = as_protobuf
+    protobuf = as_protobuf
+    proto = as_protobuf
+    protobuf_timestamp = as_protobuf
+    proto_timestamp = as_protobuf
+    pb = as_protobuf
+
+    time_diff = timediff
+    diff = timediff
+    timedelta = timediff
+    delta = timediff
+
+    as_datestring = as_date_string
+    as_date_str = as_date_string
+    as_datestr = as_date_string
+    to_date_string = as_date_string
+    to_datestring = as_date_string
+    to_date_str = as_date_string
+    to_datestr = as_date_string
+    get_date_string = as_date_string
+    get_datestring = as_date_string
+    get_datestr = as_date_string
+    get_date_string = as_date_string
+    date_string = as_date_string
+    datestring = as_date_string
+    date_str = as_date_string
+    datestr = as_date_string
+
+    get_today = today
+    get_today_date = today
+    get_todays_date = today
+    get_date_today = today
+    date_today = as_date_string
+    today_date = today
+    todays_date = today
+
+class now(str):
+    def __repr__(self) -> str: ...
+    def __str__(self) -> str: ...
+    def __new__(  # type: ignore
+        cls,
+        value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> str:
+        """Transforms the input value to a timestamp string in RFC3339 format.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+        Returns:
+            The transformed value as a string in RFC3339 format.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+        """
+    def __call__(
+        self,
+        value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> str:
+        """Transforms the input value to a timestamp string in RFC3339 format.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+        Returns:
+            The transformed value as a string in RFC3339 format.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+        """
+    @staticmethod
+    def rfc3339_timestamp(
+        value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> str:
+        """Transforms the input value to a timestamp string in RFC3339 format.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+        Returns:
+            The transformed value as a string in RFC3339 format.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+
+        Examples:
+            >>> import utcnow
+            >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00")
+            "2023-09-07T02:18:00.000000Z"
+            >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00", "+7d")
+            "2023-09-14T02:18:00.000000Z"
+            >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00+02:00")
+            "2023-09-07T00:18:00.000000Z"
+            >>> utcnow.rfc3339_timestamp(1693005993.285967)
+            "2023-08-25T23:26:33.285967Z"
+            >>> from datetime import datetime, timezone, timedelta
+            >>> tz = timezone(timedelta(hours=2, minutes=0))
+            >>> dt = datetime(2023, 4, 30, 8, 0, 0, tzinfo=tz)
+            >>> utcnow.rfc3339_timestamp(dt)
+            "2023-04-30T06:00:00.000000Z"
+        """
+    @staticmethod
+    def as_datetime(
+        value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> datetime:
+        """Transforms the input value to a datetime object.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+        Returns:
+            The transformed value as a datetime object.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+
+        Examples:
+            >>> import utcnow
+            >>> utcnow.as_datetime("2023-08-01 12:10:59.123456+02:00")
+            datetime.datetime(2023, 8, 1, 10, 10, 59, 123456, tzinfo=datetime.timezone.utc)
+        """
+    @staticmethod
+    def as_unixtime(
+        value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> float:
+        """Transforms the input value to a float value representing a timestamp as unixtime.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+        Returns:
+            The transformed value in unixtime (float).
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+
+        Examples:
+            >>> import utcnow
+            >>> utcnow.as_unixtime("1970-01-01T00:00:00.000000Z")
+            0.0
+            >>> utcnow.as_unixtime("1970-01-01T00:00:00.000000Z", "+24h")
+            86400.0
+            >>> utcnow.as_unixtime("2022-01-01 00:00:00.123456+00:00")
+            1640995200.123456
+        """
+    @staticmethod
+    def as_protobuf(
+        value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> TimestampProtobufMessage:
+        """Transforms the input value to a google.protobuf.Timestamp protobuf message.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+        Returns:
+            The transformed value as a google.protobuf.Timestamp message.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+
+        Examples:
+            >>> import utcnow
+            >>> utcnow.as_protobuf("2022-01-01 00:00:00.123456+00:00")
+            seconds: 1640995200
+            nanos: 123456000
+            >>> utcnow.as_protobuf(1234567890.05, modifier=-0.1)
+            seconds: 1234567889
+            nanos: 950000000
+        """
+    @staticmethod
+    def timediff(
+        begin: Union[str, datetime, object, int, float, Decimal, Real],
+        end: Union[str, datetime, object, int, float, Decimal, Real],
+        unit: str = "seconds",
+    ) -> float:
+        """Calculate the time difference between two timestamps.
+
+        Args:
+            begin: The beginning timestamp. Can be a string, datetime object, or a numeric unixtime value.
+            end: The ending timestamp. Can be a string, datetime object, or a numeric unixtime value.
+            unit: The unit of time to return the difference in. Defaults to "seconds".
+
+        Returns:
+            The time difference between the two timestamps in the specified unit.
+
+        Raises:
+            ValueError: If an unknown unit is specified.
+
+        Examples:
+            >>> import utcnow
+            >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-01 00:00:10")
+            10.0
+            >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-01 00:01:00", unit="minutes")
+            1.0
+            >>> utcnow.timediff("2022-01-01 00:00:00", "2022-01-02 00:00:00", unit="days")
+            1.0
+            >>> utcnow.timediff("2022-01-01T00:00:00.000000Z", "2022-01-02T06:00:00.000000Z", unit="days")
+            1.25
+            >>> utcnow.timediff(0, 7200, unit="hours")
+            2.0
+        """
+    @staticmethod
+    def as_date_string(
+        value: Union[str, datetime, object, int, float, Decimal, Real] = TODAY,
+        tz: Optional[Union[str, tzinfo]] = None,
+    ) -> str:
+        """Transforms the input value to a string representing a date (YYYY-mm-dd) without timespec or timezone.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            tz: An optional timezone for which the date is represented related to the input value.
+                If not specified, UTC timezone will be applied.
+
+        Returns:
+            A string representing a date (YYYY-mm-dd) without timespec or timezone.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+
+        Examples:
+            >>> import utcnow
+            >>> utcnow.as_date_string("2023-09-07 02:18:00")
+            "2023-09-07"
+            >>> utcnow.as_date_string("2020-01-01T00:00:00.000000Z")
+            "2020-01-01"
+            >>> utcnow.as_date_string("2020-01-01T00:00:00.000000+02:00")
+            "2019-12-31"
+            >>> utcnow.as_date_string("2020-01-01T00:00:00.000000+02:00", "+02:00")
+            "2020-01-01"
+            >>> utcnow.as_date_string(1234567890.123456)
+            "2009-02-13"
+            >>> utcnow.as_date_string(0)
+            "1970-01-01"
+            >>> utcnow.as_date_string()
+            "2023-09-07"  # current date
+        """
+    @staticmethod
+    def today(
+        tz: Optional[Union[str, tzinfo]] = None,
+    ) -> str:
+        """Returns a string representing today's date (YYYY-mm-dd) without timespec or timezone.
+
+        Args:
+            tz: An optional timezone value that is used to return today's date in the specific timezone.
+                If not specified, UTC timezone will be applied. Note that the timezone value will not be
+                represented in the returned value, only the current date (YYYY-mm-dd) in the specified timezone.
+
+        Returns:
+            A string representing today's date (YYYY-mm-dd) without timespec or timezone.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+
+        Examples:
+            >>> import pytz
+            >>> import utcnow
+            >>> utcnow.rfc3339_timestamp()
+            "2023-09-07T23:31:25.134196Z"  # current time
+            >>> utcnow.today()
+            "2023-09-07"  # current date
+            >>> timezone = pytz.timezone("Europe/Stockholm")  # UTC+02:00
+            >>> utcnow.today(tz=timezone)
+            "2023-09-08"  # current date in Europe/Stockholm timezone
+            >>> utcnow.today(tz="+01:00")
+            "2023-09-08"  # current date in a timezone with UTC offset +01:00
+        """
+    @staticmethod
+    def now(
+        value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
+        modifier: Optional[Union[str, int, float]] = 0,
+    ) -> str:
+        """Transforms the input value to a timestamp string in RFC3339 format.
+
+        Args:
+            value: A value representing a timestamp in any of the allowed input formats, or "now" if left unset.
+            modifier: An optional modifier to be added to the Unix timestamp of the value. Defaults to 0.
+                Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds).
+                Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).
+
+        Returns:
+            The transformed value as a string in RFC3339 format.
+
+        Raises:
+            ValueError: If the input value does not match allowed input formats.
+
+        Examples:
+            >>> import utcnow
+            >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00")
+            "2023-09-07T02:18:00.000000Z"
+            >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00", "+7d")
+            "2023-09-14T02:18:00.000000Z"
+            >>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00+02:00")
+            "2023-09-07T00:18:00.000000Z"
+            >>> utcnow.rfc3339_timestamp(1693005993.285967)
+            "2023-08-25T23:26:33.285967Z"
+            >>> from datetime import datetime, timezone, timedelta
+            >>> tz = timezone(timedelta(hours=2, minutes=0))
+            >>> dt = datetime(2023, 4, 30, 8, 0, 0, tzinfo=tz)
+            >>> utcnow.rfc3339_timestamp(dt)
+            "2023-04-30T06:00:00.000000Z"
+        """
+    as_string = rfc3339_timestamp
+    as_str = rfc3339_timestamp
+    as_rfc3339 = rfc3339_timestamp
+    to_string = rfc3339_timestamp
+    to_str = rfc3339_timestamp
+    to_rfc3339 = rfc3339_timestamp
+    get_string = rfc3339_timestamp
+    get_str = rfc3339_timestamp
+    get_rfc3339 = rfc3339_timestamp
+    get = rfc3339_timestamp
+    string = rfc3339_timestamp
+    str = rfc3339_timestamp
+    rfc3339 = rfc3339_timestamp
+    timestamp_rfc3339 = rfc3339_timestamp
+    ts_rfc3339 = rfc3339_timestamp
+    rfc3339_ts = rfc3339_timestamp
+    utcnow_rfc3339 = rfc3339_timestamp
+    rfc3339_utcnow = rfc3339_timestamp
+    now_rfc3339 = rfc3339_timestamp
+    rfc3339_now = rfc3339_timestamp
+    get_now = rfc3339_timestamp
+
+    as_date = as_datetime
+    as_dt = as_datetime
+    to_datetime = as_datetime
+    to_date = as_datetime
+    to_dt = as_datetime
+    get_datetime = as_datetime
+    get_date = as_datetime
+    get_dt = as_datetime
+    datetime = as_datetime
+    date = as_datetime
+    dt = as_datetime
+
+    as_unix = as_unixtime
+    as_time = as_unixtime
+    as_timestamp = as_unixtime
+    as_ut = as_unixtime
+    as_ts = as_unixtime
+    as_float = as_unixtime
+    to_unixtime = as_unixtime
+    to_unix = as_unixtime
+    to_time = as_unixtime
+    to_timestamp = as_unixtime
+    to_ut = as_unixtime
+    to_ts = as_unixtime
+    to_float = as_unixtime
+    get_unixtime = as_unixtime
+    get_unix = as_unixtime
+    get_time = as_unixtime
+    get_timestamp = as_unixtime
+    get_ut = as_unixtime
+    get_ts = as_unixtime
+    get_float = as_unixtime
+    unixtime = as_unixtime
+    unix = as_unixtime
+    time = as_unixtime
+    timestamp = as_unixtime
+    ut = as_unixtime
+    ts = as_unixtime
+
+    as_proto = as_protobuf
+    as_protobuf_timestamp = as_protobuf
+    as_proto_timestamp = as_protobuf
+    as_pb = as_protobuf
+    to_protobuf = as_protobuf
+    to_proto = as_protobuf
+    to_protobuf_timestamp = as_protobuf
+    to_proto_timestamp = as_protobuf
+    to_pb = as_protobuf
+    get_protobuf = as_protobuf
+    get_proto = as_protobuf
+    get_protobuf_timestamp = as_protobuf
+    get_proto_timestamp = as_protobuf
+    get_pb = as_protobuf
+    protobuf = as_protobuf
+    proto = as_protobuf
+    protobuf_timestamp = as_protobuf
+    proto_timestamp = as_protobuf
+    pb = as_protobuf
+
+    time_diff = timediff
+    diff = timediff
+    timedelta = timediff
+    delta = timediff
+
+    as_datestring = as_date_string
+    as_date_str = as_date_string
+    as_datestr = as_date_string
+    to_date_string = as_date_string
+    to_datestring = as_date_string
+    to_date_str = as_date_string
+    to_datestr = as_date_string
+    get_date_string = as_date_string
+    get_datestring = as_date_string
+    get_datestr = as_date_string
+    get_date_string = as_date_string
+    date_string = as_date_string
+    datestring = as_date_string
+    date_str = as_date_string
+    datestr = as_date_string
+
+    get_today = today
+    get_today_date = today
+    get_todays_date = today
+    get_date_today = today
+    date_today = as_date_string
+    today_date = today
+    todays_date = today
+
+as_string = rfc3339_timestamp
+as_str = rfc3339_timestamp
+as_rfc3339 = rfc3339_timestamp
+to_string = rfc3339_timestamp
+to_str = rfc3339_timestamp
+to_rfc3339 = rfc3339_timestamp
+get_string = rfc3339_timestamp
+get_str = rfc3339_timestamp
+get_rfc3339 = rfc3339_timestamp
+get = rfc3339_timestamp
+string = rfc3339_timestamp
+rfc3339 = rfc3339_timestamp
+timestamp_rfc3339 = rfc3339_timestamp
+ts_rfc3339 = rfc3339_timestamp
+rfc3339_ts = rfc3339_timestamp
+utcnow_rfc3339 = rfc3339_timestamp
+rfc3339_utcnow = rfc3339_timestamp
+now_rfc3339 = rfc3339_timestamp
+rfc3339_now = rfc3339_timestamp
+get_now = rfc3339_timestamp
+
+as_date = as_datetime
+as_dt = as_datetime
+to_datetime = as_datetime
+to_date = as_datetime
+to_dt = as_datetime
+get_datetime = as_datetime
+get_date = as_datetime
+get_dt = as_datetime
+date = as_datetime
+dt = as_datetime
+
+as_unix = as_unixtime
+as_time = as_unixtime
+as_timestamp = as_unixtime
+as_ut = as_unixtime
+as_ts = as_unixtime
+as_float = as_unixtime
+to_unixtime = as_unixtime
+to_unix = as_unixtime
+to_time = as_unixtime
+to_timestamp = as_unixtime
+to_ut = as_unixtime
+to_ts = as_unixtime
+to_float = as_unixtime
+get_unixtime = as_unixtime
+get_unix = as_unixtime
+get_time = as_unixtime
+get_timestamp = as_unixtime
+get_ut = as_unixtime
+get_ts = as_unixtime
+get_float = as_unixtime
+unixtime = as_unixtime
+unix = as_unixtime
+time = as_unixtime
+timestamp = as_unixtime
+ut = as_unixtime
+ts = as_unixtime
+
+as_proto = as_protobuf
+as_protobuf_timestamp = as_protobuf
+as_proto_timestamp = as_protobuf
+as_pb = as_protobuf
+to_protobuf = as_protobuf
+to_proto = as_protobuf
+to_protobuf_timestamp = as_protobuf
+to_proto_timestamp = as_protobuf
+to_pb = as_protobuf
+get_protobuf = as_protobuf
+get_proto = as_protobuf
+get_protobuf_timestamp = as_protobuf
+get_proto_timestamp = as_protobuf
+get_pb = as_protobuf
+proto = as_protobuf
+protobuf_timestamp = as_protobuf
+proto_timestamp = as_protobuf
+pb = as_protobuf
+
+time_diff = timediff
+diff = timediff
+timedelta = timediff
+delta = timediff
+
+as_datestring = as_date_string
+as_date_str = as_date_string
+as_datestr = as_date_string
+to_date_string = as_date_string
+to_datestring = as_date_string
+to_date_str = as_date_string
+to_datestr = as_date_string
+get_date_string = as_date_string
+get_datestring = as_date_string
+get_datestr = as_date_string
+get_date_string = as_date_string
+date_string = as_date_string
+datestring = as_date_string
+date_str = as_date_string
+datestr = as_date_string
+
+get_today = today
+get_today_date = today
+get_todays_date = today
+get_date_today = today
+date_today = as_date_string
+today_date = today
+todays_date = today
+
+__all__ = [
+    "__version__",
+    "__version_info__",
+    "__author__",
+    "__email__",
+    "utcnow",
+    "now",
+    "as_date_string",
+    "as_datetime",
+    "as_protobuf",
+    "as_unixtime",
+    "rfc3339_timestamp",
+    "timediff",
+    "today",
+    "_is_numeric",
+    "_timestamp_to_datetime",
+    "_transform_value",
+]

--- a/utcnow/__init__.pyi
+++ b/utcnow/__init__.pyi
@@ -4,7 +4,8 @@ import functools
 from datetime import datetime, tzinfo
 from decimal import Decimal
 from numbers import Real
-from typing import Any, Generic, Optional, Type, TypeVar, Union
+from types import EllipsisType, FunctionType, MethodType, MethodWrapperType, WrapperDescriptorType
+from typing import Any, Generic, Optional, Type, TypeVar, Union, cast
 
 from utcnow.protobuf import TimestampProtobufMessage
 
@@ -295,6 +296,7 @@ class TimeSynchronizer(Generic[TS]):
     """
 
     def __new__(cls: Type[TimeSynchronizer[TS]]) -> TimeSynchronizer[TS]: ...
+    def __init__(self) -> None: ...
     def __call__(
         self: TimeSynchronizer[TS],
         value: Union[str, datetime, object, int, float, Decimal, Real] = NOW,
@@ -357,11 +359,26 @@ class TimeSynchronizer(Generic[TS]):
     @property
     def frozen(self) -> bool: ...
 
-class __synchronizer:
-    class synchronizer(TimeSynchronizer):
-        pass
+class TimeSynchronizerResult(TimeSynchronizer[TS]):
+    def __new__(cls: Type[TimeSynchronizerResult[TS]]) -> TimeSynchronizerResult[TS]: ...
+    def __eq__(self, other: Any) -> bool:
+        return (
+            True
+            if (
+                other is Type[TimeSynchronizerResult[TS]]
+                or other is TimeSynchronizer[TS]
+                or other is Type[TimeSynchronizer[TS]]
+                or other is TimeSynchronizerResult[TS]
+                or other is TimeSynchronizerResult[TimeSynchronizer[TS]]
+                or other is Type[TimeSynchronizerResult[TimeSynchronizer[TS]]]
+            )
+            else False
+        )
 
-__synchronizer__ = synchronizer = TimeSynchronizer[__synchronizer.synchronizer]()
+class __synchronizer(TimeSynchronizer[TS], metaclass=type):
+    pass
+
+synchronizer = __synchronizer__ = synchronizer__ = __synchronizer.__new__(__synchronizer)
 
 class utcnow(str):
     def __repr__(self) -> str: ...

--- a/utcnow/interface.py
+++ b/utcnow/interface.py
@@ -2,7 +2,7 @@
 import sys
 from typing import List, Optional
 
-from utcnow import rfc3339_timestamp, unixtime
+from utcnow import as_unixtime, rfc3339_timestamp
 
 
 def error_message(message: str, usage: Optional[str] = None) -> str:
@@ -62,7 +62,7 @@ def cli_entrypoint(argv: Optional[List[str]] = None) -> int:
             from_value, to_value = argv
 
             try:
-                unixtime_from = unixtime(from_value)
+                unixtime_from = as_unixtime(from_value)
             except ValueError:
                 print(
                     error_message(f"invalid input value for 'from' argument: \"{from_value}\".", usage), file=sys.stderr
@@ -70,7 +70,7 @@ def cli_entrypoint(argv: Optional[List[str]] = None) -> int:
                 return 1
 
             try:
-                unixtime_to = unixtime(to_value)
+                unixtime_to = as_unixtime(to_value)
             except ValueError:
                 print(error_message(f"invalid input value for 'to' argument: \"{to_value}\".", usage), file=sys.stderr)
                 return 1
@@ -106,7 +106,7 @@ def cli_entrypoint(argv: Optional[List[str]] = None) -> int:
                 argv.pop(argv.index("--"))
 
             if not argv:
-                print(rfc3339_timestamp() if output_unixtime is False else str(unixtime()))
+                print(rfc3339_timestamp() if output_unixtime is False else str(as_unixtime()))
             else:
                 values = [
                     (
@@ -123,7 +123,7 @@ def cli_entrypoint(argv: Optional[List[str]] = None) -> int:
                 output = ""
                 for value in values:
                     try:
-                        output += rfc3339_timestamp(value) if output_unixtime is False else str(unixtime(value))
+                        output += rfc3339_timestamp(value) if output_unixtime is False else str(as_unixtime(value))
                         output += "\n"
                     except ValueError:
                         print(error_message(f'invalid input value: "{value}".'), file=sys.stderr)


### PR DESCRIPTION
## Inline API documentation

### `NAME`

`utcnow` - Package for formatting arbitrary timestamps as strict RFC 3339.

### `DESCRIPTION`

Timestamps as RFC 3339 (Date & Time on the Internet) formatted strings with conversion functionality from other timestamp formats or for timestamps on other timezones. Additionally converts timestamps from datetime objects and other common date utilities.

```python
# Transforms the input value to a timestamp string in RFC 3339 format.
utcnow.rfc3339_timestamp(value, modifier)

# Transforms the input value to a datetime object.
utcnow.as_datetime(value, modifier)

# Transforms the input value to a float value representing unixtime.
utcnow.as_unixtime(value, modifier)

# Transforms the input value to a google.protobuf.Timestamp message.
utcnow.as_protobuf(value, modifier)
```

`value` — A value representing a timestamp in any of the allowed input formats, or "now" if left unset.

`modifier` — An optional modifier to be added to the Unix timestamp of the value. Defaults to 0. Can be specified in seconds (int or float) or as string, for example "+10d" (10 days => 864000 seconds). Can also be set to a negative value, for example "-1h" (1 hour => -3600 seconds).

#### Examples:

A few examples of transforming an arbitrary timestamp value to a RFC 3339 timestamp string.

```pycon
>>> import utcnow

>>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00")
"2023-09-07T02:18:00.000000Z"

>>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00", "+7d")
"2023-09-14T02:18:00.000000Z"

>>> utcnow.rfc3339_timestamp("2023-09-07 02:18:00+02:00")
"2023-09-07T00:18:00.000000Z"

>>> utcnow.rfc3339_timestamp(1693005993.285967)
"2023-08-25T23:26:33.285967Z"

>>> utcnow.rfc3339_timestamp()
"2023-09-07T01:04:38.091041Z"  # current time
```

Returned timestamps follow RFC 3339 (Date and Time on the Internet: Timestamps): https://tools.ietf.org/html/rfc3339.

Timestamps are converted to UTC timezone which we'll note in the timestamp with the "Z" syntax instead of the also accepted "+00:00". "Z" stands for UTC+0 or "Zulu time" and refers to the zone description of zero hours.

Timestamps are expressed as a date-time (not a Python datetime object), including the full date (the "T" between the date and the time is optional in RFC 3339 (but not in ISO 8601) and usually describes the beginning of the time part.

Timestamps are 27 characters long in the format: "YYYY-MM-DDTHH:mm:ss.ffffffZ". 4 digit year, 2 digit month, 2 digit days, "T", 2 digit hours, 2 digit minutes, 2 digit seconds, 6 fractional second digits (microseconds -> nanoseconds), followed by the timezone identifier for UTC: "Z".

The library is specified to return timestamps with 6 fractional second digits, which means timestamps down to the microsecond level. Having a six-digit fraction of a second is currently the most common way that timestamps are shown at this date.

#### See also:

```python
# Transforms the input value to a string representing a date (YYYY-mm-dd) without timespec or indicated timezone.
# An optional `tz` argument can be used to return the date in the specific timezone.
utcnow.as_date_string(value, tz)

# Returns a string representing today's date (YYYY-mm-dd) without timespec or indicated timezone.
# An optional `tz` argument can be used to return today's date in the specific timezone.
utcnow.today(tz)

# Calculate the time difference between two timestamps.
utcnow.timediff(begin, end, unit)
```

---

## Precision in `modifier` and `utcnow.timediff`

Added modifier and timediff support for milliseconds, microseconds and nanoseconds _(although nanosecond precision will currently not use native nanoseconds, and will return microseconds * 1000)_.

Common modifier multipliers: 
- "s" (seconds)
- "m" (minutes)
- "h" (hours)
- "d" (days)

Precision modifier multiplicers (new):
- "ms" (milliseconds)
- "us" (microseconds)
- "ns" (nanoseconds)

---

## Deprecation warnings

Added deprecation warnings to all other non-standard transformation functions (that will still work for the time being) – for example `utcnow.as_str`, `utcnow.get_unixtime` or `utcnow.datetime`, etc.

---

## Refactoring

Major refactoring of the library to actually use a `ModuleType` instead of creating a class object (that was used as a faked module) when importing `utcnow`. 

#### Previously

```pycon
>>> import utcnow

>>> type(utcnow)
<class 'utcnow._module'>

>>> len(dir(utcnow))
197 (exported items from module / class)
```

#### After refactoring

```pycon
>>> import utcnow

>>> type(utcnow)
<class 'module'>

>>> len(dir(utcnow))
23 (exported items from module)
```

----

## Freeze the current time in `utcnow` with `utcnow.synchronizer`

There's a context manager available at `utcnow.synchronizer` to freeze the current time of `utcnow` to a specific value of your choice or to the current time when entering the context manager.

This has been added to accomodate for the use-case of needing to fetch the current time in different places as part of a call chain, where it's also either difficult or you're unable to pass the initial timestamp value as an argument down the chain, but you want to receive the exact same timestamp from `utcnow` to be returned for each call, although some microseconds would have passed since last call.

```python
timestamp_before = utcnow.get()

with utcnow.synchronizer:
    # the current time (fetched through utcnow) is now frozen to the time when the
    # context manager was opened.
    timestamp_in_context = utcnow.get()

    # even when sleeping or awaiting, the time will stay frozen for as long as
    # we haven't exited the context.
    sleep(1)
    timestamp_1s_later = utcnow.get()  # same value as timestamp_in_context

timestamp_after = utcnow.get()

# timestamp_before      -> '2023-09-25T22:53:04.733040Z'
# timestamp_in_context  -> '2023-09-25T22:53:04.733076Z' (timestamp_before + 36µs)
# timestamp_1s_later    -> '2023-09-25T22:53:04.733076Z' (timestamp_before + 36µs)
# timestamp_after       -> '2023-09-25T22:53:05.738224Z' (timestamp_before + ~1s)
```

The `utcnow.synchronizer(value, modifier)` can also be initialized with a specific timestamp value to freeze the current time to, instead of the current time when entering the context manager. The same kind of arguments as for `utcnow.rfc3339_timestamp()` (`utcnow.get()`) can be used also for `utcnow.synchronizer`.

```python
with utcnow.synchronizer("2000-01-01"):
    # the current time (fetched through utcnow) is now frozen to UTC midnight,
    # new years eve 2000.

    timestamp_in_context = utcnow.get()
    # '2000-01-01T00:00:00.000000Z'

    datetime_in_context = utcnow.as_datetime()
    # datetime.datetime(2000, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)

    unixtime_in_context = utcnow.as_unixtime()
    # 946684800.0

    timestamp_in_context_plus_24h = utcnow.get("now", "+24h")
    # '2000-01-02T00:00:00.000000Z'
```

#### An example of how `utcnow.synchronizer` can be used to freeze the creation time of an object and its children

A common use-case for `utcnow.synchronizer` is to freeze the creation time of an object and its children, for example when creating a bunch of objects in a chunk, if we are expected to apply the exact same creation time of all objects in the chunk using the same value.

`SomeModel` is a simple class that stores `created_at` when the object is initiated. Objects of the type may also contain a list of `items`, which in pratice is children of the same type. If creating a parent `SomeModel` object with two children stored to its `items` list all together in a chunk (for example as part of a storage API request), we may want to use the same timestamp for all three objects (the parent and the children).

```python
class SomeModel:
    _created_at: str
    items: List[SomeModel]

    def __init__(self, items: Optional[List[SomeModel]] = None) -> None:
        self._created_at = utcnow.rfc3339_timestamp()
        self.items = items if items is not None else []

    @property
    def created_at(self) -> str:
        return self._created_at

    def __repr__(self) -> str:
        base_ = f"{type(self).__name__} [object at {hex(id(self))}], created_at='{self._created_at}'"
        if self.items:
            return f"<{base_}, items={self.items}>"
        return f"<{base_}>"


# without freezing the current time, the timestamps would be different for each item and
# the parent although they were created in the same chunk - this may be desired in a bunch
# of cases, but not always.

a = SomeModel(items=[
    SomeModel(),
    SomeModel(),
])
# a = <SomeModel [object at 0x103a01350], created_at='2023-09-25T23:35:50.371100Z', items=[
#     <SomeModel [object at 0x1039ff590], created_at='2023-09-25T23:35:50.371078Z'>,
#     <SomeModel [object at 0x103a01290], created_at='2023-09-25T23:35:50.371095Z'>
# ]>

with utcnow.synchronizer:
    b = SomeModel(items=[
        SomeModel(),
        SomeModel(),
    ])
# b = <SomeModel [object at 0x103a01350], created_at='2023-09-25T23:35:50.371100Z', items=[
#     <SomeModel [object at 0x1039ff590], created_at='2023-09-25T23:35:50.371100Z'>,
#     <SomeModel [object at 0x103a01290], created_at='2023-09-25T23:35:50.371100Z'>
# ]>

```

It's not possible to chain `utcnow.synchronizer` context managers to freeze the current time to different values at different points in the call chain. If a `utcnow.synchronizer` context is already opened a second attempt to create or open a context will result in a raised exception.

```python
with utcnow.synchronizer:
    # this is ok
    with utcnow.synchronizer:
        # we'll never get here
        ...

# Traceback (most recent call last):
#   File "<stdin>", line 2, in <module>
#   File ".../.../.../utcnow/__init__.py", line 245, in __enter__
#     raise RuntimeError("'utcnow.synchronizer' context cannot be nested (library time already synchronized)")
# RuntimeError: 'utcnow.synchronizer' context cannot be nested (library time already synchronized)
```
